### PR TITLE
Rename Traits => HeatExchangeTraits

### DIFF
--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -13,7 +13,7 @@ using FluidProperties: molCO₂, molH₂O, molO₂, molN₂
 using BiophysicalGeometry
 using BiophysicalGeometry: AbstractBody, shape
 
-export Organism, Traits, EndoModelPars, InsulationParameters, ExternalConductionParameters,
+export Organism, HeatExchangeTraits, EndoModelPars, InsulationParameters, ExternalConductionParameters,
   InternalConductionParameters, RadiationParameters, ConvectionParameters, EvaporationParameters, 
   HydraulicParameters, RespirationParameters, MetabolismParameters
 

--- a/src/organism.jl
+++ b/src/organism.jl
@@ -11,8 +11,19 @@ abstract type AbstractModelParameters end
 
 abstract type AbstractFunctionalTraits end
 
-#TODO fix types
-struct Traits{
+shapepars(t::AbstractFunctionalTraits) = stripparams(t.shape_pars)
+insulationpars(t::AbstractFunctionalTraits) = stripparams(t.insulation_pars)
+conductionpars_external(t::AbstractFunctionalTraits) = stripparams(t.conduction_pars_external)
+conductionpars_internal(t::AbstractFunctionalTraits) = stripparams(t.conduction_pars_internal)
+convectionpars(t::AbstractFunctionalTraits) = stripparams(t.convection_pars)
+radiationpars(t::AbstractFunctionalTraits) = stripparams(t.radiation_pars)
+evaporationpars(t::AbstractFunctionalTraits) = stripparams(t.evaporation_pars)
+hydraulicpars(t::AbstractFunctionalTraits) = stripparams(t.hydraulic_pars)
+respirationpars(t::AbstractFunctionalTraits) = stripparams(t.respiration_pars)
+metabolismpars(t::AbstractFunctionalTraits) = stripparams(t.metabolism_pars)
+
+# TODO more specific subtypes
+struct HeatExchangeTraits{
         SP<:AbstractShape,
         IN<:AbstractMorphologyParameters,
         CE<:AbstractMorphologyParameters,
@@ -49,17 +60,7 @@ traits(o::AbstractOrganism) = o.traits
 #shape(o::AbstractOrganism) = shape(body(o)) # gets the shape from an object of type AbstractOrganism
 #insulation(o::AbstractOrganism) = insulation(body(o)) # gets the insulation from an object of type AbstractOrganism
 
-shapepars(t::AbstractFunctionalTraits) = stripparams(t.shape_pars)
-insulationpars(t::AbstractFunctionalTraits) = stripparams(t.insulation_pars)
-conductionpars_external(t::AbstractFunctionalTraits) = stripparams(t.conduction_pars_external)
-conductionpars_internal(t::AbstractFunctionalTraits) = stripparams(t.conduction_pars_internal)
-convectionpars(t::AbstractFunctionalTraits) = stripparams(t.convection_pars)
-radiationpars(t::AbstractFunctionalTraits) = stripparams(t.radiation_pars)
-evaporationpars(t::AbstractFunctionalTraits) = stripparams(t.evaporation_pars)
-hydraulicpars(t::AbstractFunctionalTraits) = stripparams(t.hydraulic_pars)
-respirationpars(t::AbstractFunctionalTraits) = stripparams(t.respiration_pars)
-metabolismpars(t::AbstractFunctionalTraits) = stripparams(t.metabolism_pars)
-
+# Forwarding methods from organism to traits
 shapepars(o::AbstractOrganism) = shapepars(traits(o))
 insulationpars(o::AbstractOrganism) = insulationpars(traits(o))
 conductionpars_external(o::AbstractOrganism) = conductionpars_external(traits(o))

--- a/test/ectotherm.jl
+++ b/test/ectotherm.jl
@@ -323,7 +323,7 @@ metabolism_pars = MetabolismParameters(;
     model = AndrewsPough2(),
 )
 
-traits = Traits(
+traits = HeatExchangeTraits(
     shape_pars,
     InsulationParameters(),
     conduction_pars_external,

--- a/test/endotherm.jl
+++ b/test/endotherm.jl
@@ -155,7 +155,7 @@ for shape_number in 1:4
             longwave_depth_fraction=endo_input.XR,
         )
 
-        traits = Traits(
+        traits = HeatExchangeTraits(
             shape_pars,
             insulation_pars,
             conduction_pars_external,


### PR DESCRIPTION
This makes it clearer what the object is when used e.g. in BiophysicalBehaviour, where there may be more kinds of traits.

Closee #18 