### PR TITLE
add heat_balance function for leaves and IPOPT solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HeatExchange"
 uuid = "720bd838-cdd6-4aad-926b-452b962dce21"
-authors = ["Michael Kearney, Urtzi Enriquez Urzelai and Rafael Schouten"]
 version = "0.1.0"
+authors = ["Michael Kearney, Urtzi Enriquez Urzelai and Rafael Schouten"]
 
 [deps]
 BiophysicalGeometry = "06c61620-4f66-4020-a018-07befe374221"
@@ -13,14 +13,14 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 
 [sources]
+BiophysicalGeometry = {rev = "characteristic-dimension-options", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
 FluidProperties = {rev = "main", url = "https://github.com/BiophysicalEcology/FluidProperties.jl"}
-BiophysicalGeometry = {rev = "main", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
 
 [compat]
 Aqua = "0.8"
 BiophysicalGeometry = "0.1"
-ConstructionBase = "1"
 CSV = "0.10.15"
+ConstructionBase = "1"
 DataFrames = "1"
 DataStructures = "0.18, 0.19"
 FluidProperties = "0.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 
 [sources]
-BiophysicalGeometry = {rev = "characteristic-dimension-options", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
+BiophysicalGeometry = {rev = "rename-to-aspect_ratio", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
 FluidProperties = {rev = "main", url = "https://github.com/BiophysicalEcology/FluidProperties.jl"}
 
 [compat]

--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -21,7 +21,7 @@ using FluidProperties:
     molO₂,
     molN₂
 
-using BiophysicalGeometry: AbstractBody, shape
+using BiophysicalGeometry: AbstractBody, shape, CharDimFormula, VolumeCubeRoot, ShortestDimension
 
 export Organism,
     HeatExchangeTraits,
@@ -32,6 +32,7 @@ export Organism,
     RadiationParameters,
     ConvectionParameters,
     EvaporationParameters,
+    LeafEvaporationParameters,
     HydraulicParameters,
     RespirationParameters,
     MetabolismParameters
@@ -91,6 +92,8 @@ export ConductanceCoeffs,
     Absorptivities,
     InsulationProperties,
     GeometryVariables
+
+export CharDimFormula, VolumeCubeRoot, ShortestDimension
 
 export MetabolicRateEquation, metabolic_rate, AndrewsPough2, Kleiber, McKechnieWolf
 

--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -31,7 +31,7 @@ export Organism,
     InternalConductionParameters,
     RadiationParameters,
     ConvectionParameters,
-    EvaporationParameters,
+    AnimalEvaporationParameters,
     LeafEvaporationParameters,
     HydraulicParameters,
     RespirationParameters,
@@ -58,7 +58,7 @@ export get_Tb
 export solar,
     radiation_in, radiation_out, evaporation, conduction, convection, nusselt_free, nusselt_forced
 
-export ectotherm, surface_and_lung_temperature
+export heat_balance, solve_temperature, surface_and_lung_temperature
 
 export radiant_temperature, insulation_radiant_temperature, compressed_radiant_temperature
 
@@ -95,7 +95,7 @@ export ConductanceCoeffs,
 
 export CharDimFormula, VolumeCubeRoot, ShortestDimension
 
-export MetabolicRateEquation, metabolic_rate, AndrewsPough2, Kleiber, McKechnieWolf
+export MetabolicRateEquation, metabolic_rate, AndrewsPough2, Kleiber, McKechnieWolf, PlantDarkRespiration
 
 export OxygenJoulesConversion, O2_to_Joules, Joules_to_O2, Typical, Kleiber1961
 
@@ -116,6 +116,7 @@ include("insulation.jl")
 
 include("ectotherm/lung_and_surface_temperature.jl")
 include("ectotherm/ectotherm.jl")
+include("leaf/leaf.jl")
 
 include("endotherm/ellipsoid_model.jl")
 include("endotherm/radiant_temperature.jl")

--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -126,5 +126,6 @@ include("endotherm/mean_skin_temperature.jl")
 include("endotherm/net_metabolic_heat.jl")
 include("endotherm/skin_and_insulation_temperature.jl")
 include("endotherm/endotherm.jl")
+include("endotherm/heat_balance.jl")
 
 end

--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -21,7 +21,7 @@ using FluidProperties:
     molO₂,
     molN₂
 
-using BiophysicalGeometry: AbstractBody, shape, CharDimFormula, VolumeCubeRoot, ShortestDimension
+using BiophysicalGeometry: AbstractBody, shape, outer_insulation
 
 export Organism,
     HeatExchangeTraits,
@@ -93,7 +93,7 @@ export ConductanceCoeffs,
     InsulationProperties,
     GeometryVariables
 
-export CharDimFormula, VolumeCubeRoot, ShortestDimension
+export CharacteristicDimFormula, VolumeCubeRoot, ScaledDimension, characteristic_dimension
 
 export MetabolicRateEquation, metabolic_rate, AndrewsPough2, Kleiber, McKechnieWolf, PlantDarkRespiration
 

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -370,7 +370,7 @@ Compute surface evaporation based on mass transfer coefficient, wetness fraction
 and vapor density gradient between surface and air.
 
 # Arguments
-- `evap_pars::EvaporationParameters`: Evaporation parameters (wetness, eye_fraction, bare_skin_fraction)
+- `evap_pars::AnimalEvaporationParameters`: Evaporation parameters (wetness, eye_fraction, bare_skin_fraction)
 - `mass::TransferCoefficients`: Mass transfer coefficients (combined, free, forced)
 - `atmos::AtmosphericConditions`: Atmospheric conditions (relative_humidity, atmospheric_pressure)
 - `area`: Total surface area for evaporation
@@ -385,7 +385,7 @@ and vapor density gradient between surface and air.
 NamedTuple with evaporation_heat_flow, m_cut, m_eyes
 """
 function evaporation(
-    evap_pars::EvaporationParameters,
+    evap_pars::AnimalEvaporationParameters,
     mass::TransferCoefficients,
     atmos::AtmosphericConditions,
     area,

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -364,6 +364,17 @@ function nusselt_forced(shape::Union{Ellipsoid,Sphere,DesertIguana,LeopardFrog},
     0.35 * reynolds_number ^ 0.6 # from McAdams, W.H. 1954. Heat Transmission. McGraw-Hill, New York, p.532
 end
 
+function _vapour_densities(surface_temperature, air_temperature, water_potential,
+                           relative_humidity, atmospheric_pressure; gas_fractions)
+    molar_mass_water = (u"kg"(1u"molH₂O")) / 1u"mol"
+    rh_surf = exp(water_potential / (Unitful.R / molar_mass_water * surface_temperature))
+    surface_vapour_density =
+        wet_air_properties(surface_temperature, rh_surf, atmospheric_pressure; gas_fractions).vapour_density
+    air_vapour_density =
+        wet_air_properties(air_temperature, relative_humidity, atmospheric_pressure; gas_fractions).vapour_density
+    return (; surface_vapour_density, air_vapour_density)
+end
+
 """
     evaporation(evap_pars, mass, atmos, area, surface_temperature, air_temperature; kw...)
 
@@ -403,15 +414,10 @@ function evaporation(
     effective_area_insulated = (area - effective_area_eye) * skin_wetness * (1 - bare_skin_fraction)
     effective_area_bare = (area - effective_area_eye) * skin_wetness * bare_skin_fraction
 
-    # get vapour density at surface based on water potential of body
-    molar_mass_water = (u"kg"(1u"molH₂O")) / 1u"mol"
-    rh_surf = exp(water_potential / (Unitful.R / molar_mass_water * surface_temperature))
-    wet_air_out = wet_air_properties(surface_temperature, rh_surf, atmospheric_pressure; gas_fractions)
-    surface_vapour_density = wet_air_out.vapour_density
-
-    # get air vapour density
-    wet_air_out = wet_air_properties(air_temperature, relative_humidity, atmospheric_pressure; gas_fractions)
-    air_vapour_density = wet_air_out.vapour_density
+    (; surface_vapour_density, air_vapour_density) = _vapour_densities(
+        surface_temperature, air_temperature, water_potential,
+        relative_humidity, atmospheric_pressure; gas_fractions,
+    )
 
     # mass of water lost
     m_eyes = mass.combined * effective_area_eye * (surface_vapour_density - air_vapour_density) # forced + free
@@ -484,12 +490,10 @@ function evaporation(
             (effective_adaxial_mass_transfer + boundary_layer_mass_transfer_coefficient)
 
     # vapour density at leaf surface and in air (same as animal evaporation)
-    molar_mass_water = (u"kg"(1u"molH₂O")) / 1u"mol"
-    rh_surf = exp(water_potential / (Unitful.R / molar_mass_water * surface_temperature))
-    wet_air_out = wet_air_properties(surface_temperature, rh_surf, atmospheric_pressure; gas_fractions)
-    surface_vapour_density = wet_air_out.vapour_density
-    wet_air_out = wet_air_properties(air_temperature, relative_humidity, atmospheric_pressure; gas_fractions)
-    air_vapour_density = wet_air_out.vapour_density
+    (; surface_vapour_density, air_vapour_density) = _vapour_densities(
+        surface_temperature, air_temperature, water_potential,
+        relative_humidity, atmospheric_pressure; gas_fractions,
+    )
 
     # transpiration mass flux and latent heat
     transpiration_water_loss =

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -426,3 +426,75 @@ function evaporation(
     m_cut = uconvert(u"g/s", m_cut)
     return (; evaporation_heat_flow, m_cut, m_eyes)
 end
+
+"""
+    evaporation(evap_pars::LeafEvaporationParameters, mass, atmos, area, surface_temperature, air_temperature; kw...)
+
+Compute leaf transpiration using stomatal vapour conductances combined with the boundary layer
+mass transfer coefficient from a prior `convection()` call. Using `mass` from `convection()`
+ensures that the same body geometry and convective enhancement factor govern both heat and
+mass transfer — no separate leaf width or enhancement parameter is needed.
+
+Stomatal conductances (mol/m²/s) are converted to m/s via the ideal gas relation
+`h = g_mol × R·T/P`, then combined with the boundary layer in series+parallel.
+
+# Arguments
+- `evap_pars::LeafEvaporationParameters`: Stomatal and cuticular conductances
+- `mass::TransferCoefficients`: Mass transfer coefficients from `convection()` (combined, free, forced)
+- `atmos::AtmosphericConditions`: Atmospheric conditions (relative_humidity, atmospheric_pressure)
+- `area`: Total leaf surface area
+- `surface_temperature`: Leaf surface temperature
+- `air_temperature`: Air temperature
+
+# Keywords
+- `water_potential`: Leaf water potential (J/kg), default 0.0 (fully saturated surface)
+- `gas_fractions::GasFractions`: Gas fractions for air properties
+
+# Returns
+NamedTuple with evaporation_heat_flow, transpiration_water_loss
+"""
+function evaporation(
+    evap_pars::LeafEvaporationParameters,
+    mass::TransferCoefficients,
+    atmos::AtmosphericConditions,
+    area,
+    surface_temperature,
+    air_temperature;
+    water_potential=0.0u"J/kg",
+    gas_fractions::GasFractions=GasFractions(),
+)
+    (; abaxial_vapour_conductance, adaxial_vapour_conductance, cuticular_conductance) = evap_pars
+    (; relative_humidity, atmospheric_pressure) = atmos
+
+    # convert stomatal conductances from mol/m²/s → m/s via ideal gas: h = g_mol × R·T/P
+    molar_volume_air = Unitful.R * air_temperature / atmospheric_pressure
+    effective_abaxial_mass_transfer =
+        (abaxial_vapour_conductance + cuticular_conductance / 2) * molar_volume_air
+    effective_adaxial_mass_transfer =
+        (adaxial_vapour_conductance + cuticular_conductance / 2) * molar_volume_air
+
+    # series+parallel combination: each surface in series with boundary layer, both sides parallel
+    # mass.combined uses the same body geometry and enhancement factor as convection heat transfer
+    boundary_layer_mass_transfer_coefficient = mass.combined
+    effective_mass_transfer_coefficient =
+        (0.5 * effective_abaxial_mass_transfer * boundary_layer_mass_transfer_coefficient) /
+            (effective_abaxial_mass_transfer + boundary_layer_mass_transfer_coefficient) +
+        (0.5 * effective_adaxial_mass_transfer * boundary_layer_mass_transfer_coefficient) /
+            (effective_adaxial_mass_transfer + boundary_layer_mass_transfer_coefficient)
+
+    # vapour density at leaf surface and in air (same as animal evaporation)
+    molar_mass_water = (u"kg"(1u"molH₂O")) / 1u"mol"
+    rh_surf = exp(water_potential / (Unitful.R / molar_mass_water * surface_temperature))
+    wet_air_out = wet_air_properties(surface_temperature, rh_surf, atmospheric_pressure; gas_fractions)
+    surface_vapour_density = wet_air_out.vapour_density
+    wet_air_out = wet_air_properties(air_temperature, relative_humidity, atmospheric_pressure; gas_fractions)
+    air_vapour_density = wet_air_out.vapour_density
+
+    # transpiration mass flux and latent heat
+    transpiration_water_loss =
+        effective_mass_transfer_coefficient * area * (surface_vapour_density - air_vapour_density)
+    latent_heat_vaporisation = enthalpy_of_vaporisation(air_temperature)
+    evaporation_heat_flow = uconvert(u"W", transpiration_water_loss * latent_heat_vaporisation)
+    transpiration_water_loss = uconvert(u"g/s", transpiration_water_loss)
+    return (; evaporation_heat_flow, transpiration_water_loss)
+end

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -176,7 +176,7 @@ end
 Calculate combined free and forced convective heat transfer for an organism.
 
 # Keywords
-- `body`: Organism body with geometry (must have `shape` and `geometry.characteristic_dimension`)
+- `body`: Organism body with geometry (must have `shape` and `geometry`)
 - `area`: Surface area for convection
 - `air_temperature`: Air temperature
 - `surface_temperature`: Surface temperature
@@ -202,9 +202,10 @@ function convection(;
     fluid,
     gas_fractions::GasFractions=GasFractions(),
     convection_enhancement=1.0,
+    characteristic_dimension_formula::CharacteristicDimFormula=VolumeCubeRoot(),
 )
     thermal_expansion_coefficient = 1 / air_temperature
-    characteristic_dimension = body.geometry.characteristic_dimension
+    characteristic_dim = characteristic_dimension(characteristic_dimension_formula, body)
     dry_air_out = dry_air_properties(air_temperature, atmospheric_pressure; gas_fractions)
     vapour_diffusivity = dry_air_out.vapour_diffusivity
     # checking to see if the fluid is water, not air
@@ -233,30 +234,30 @@ function convection(;
     if temperature_difference <= 0.0u"K" # stability check - avoiding zero
         temperature_difference = temperature_difference + 0.00001u"K"
     end
-    grashof_number = abs(((fluid_density^2) * thermal_expansion_coefficient * Unitful.gn * (characteristic_dimension^3) * temperature_difference) / (dynamic_viscosity^2))
-    reynolds_number = fluid_density * wind_speed * characteristic_dimension / dynamic_viscosity
+    grashof_number = abs(((fluid_density^2) * thermal_expansion_coefficient * Unitful.gn * (characteristic_dim^3) * temperature_difference) / (dynamic_viscosity^2))
+    reynolds_number = fluid_density * wind_speed * characteristic_dim /dynamic_viscosity
     free_nusselt_number = nusselt_free(body.shape, grashof_number, prandtl_number)
-    free_heat_transfer_coefficient = (free_nusselt_number * fluid_conductivity) / characteristic_dimension # heat transfer coefficient, free
+    free_heat_transfer_coefficient = (free_nusselt_number * fluid_conductivity) / characteristic_dim # heat transfer coefficient, free
     # calculating the Sherwood number from the Colburn analogy
     # Bird, Stewart & Lightfoot, 1960. Transport Phenomena. Wiley.
     free_sherwood_number = free_nusselt_number * (schmidt_number / prandtl_number)^(1 / 3) # Sherwood number, free
     # calculating the mass transfer coefficient from the Sherwood number
-    free_mass_transfer_coefficient = free_sherwood_number * vapour_diffusivity / characteristic_dimension # mass transfer coefficient, free
+    free_mass_transfer_coefficient = free_sherwood_number * vapour_diffusivity / characteristic_dim # mass transfer coefficient, free
     free_convection_flow = free_heat_transfer_coefficient * area * (surface_temperature - air_temperature) # free convective heat loss at surface
     # forced convection
     forced_nusselt_number = nusselt_forced(body.shape, reynolds_number) * convection_enhancement
     # forced convection for object
-    forced_heat_transfer_coefficient = forced_nusselt_number * fluid_conductivity / characteristic_dimension # heat transfer coefficient, forced
+    forced_heat_transfer_coefficient = forced_nusselt_number * fluid_conductivity / characteristic_dim # heat transfer coefficient, forced
     forced_sherwood_number = forced_nusselt_number * (schmidt_number / prandtl_number)^(1 / 3) # Sherwood number, forced
-    forced_mass_transfer_coefficient = forced_sherwood_number * vapour_diffusivity / characteristic_dimension # mass transfer coefficient
+    forced_mass_transfer_coefficient = forced_sherwood_number * vapour_diffusivity / characteristic_dim # mass transfer coefficient
     forced_convection_flow = forced_heat_transfer_coefficient * area * (surface_temperature - air_temperature) # forced convective heat transfer
     # combined free and forced convection
     # using Bird, Stewart & Lightfoot's mixed convection formula (p. 445, Transport Phenomena, 2002)
     combined_nusselt_number = (free_nusselt_number^3 + forced_nusselt_number^3)^(1 / 3)
-    combined_heat_transfer_coefficient = combined_nusselt_number * (fluid_conductivity / characteristic_dimension) # mixed convection heat transfer
+    combined_heat_transfer_coefficient = combined_nusselt_number * (fluid_conductivity / characteristic_dim) # mixed convection heat transfer
     convection_flow = combined_heat_transfer_coefficient * area * (surface_temperature - air_temperature) # total convective heat loss
     combined_sherwood_number = combined_nusselt_number * (schmidt_number / prandtl_number)^(1 / 3) # Sherwood number, combined
-    combined_mass_transfer_coefficient = combined_sherwood_number * vapour_diffusivity / characteristic_dimension # mass transfer coefficient, combined
+    combined_mass_transfer_coefficient = combined_sherwood_number * vapour_diffusivity / characteristic_dim # mass transfer coefficient, combined
 
     heat = TransferCoefficients(combined_heat_transfer_coefficient, free_heat_transfer_coefficient, forced_heat_transfer_coefficient)
     mass = TransferCoefficients(combined_mass_transfer_coefficient, free_mass_transfer_coefficient, forced_mass_transfer_coefficient)

--- a/src/ectotherm/ectotherm.jl
+++ b/src/ectotherm/ectotherm.jl
@@ -1,63 +1,107 @@
-# ectotherm heat balance
+# ectotherm / leaf heat balance
 
 """
-    ectotherm(core_temperature, organism::Organism, e)
+    _radiative_convective_flows(surface_temperature, organism, environment_pars, environment_vars)
 
-Calculate heat balance for an ectotherm at a given core temperature.
+Private helper: compute solar, longwave, and convective heat flows for a body surface.
 
-Computes all heat flow components (solar, longwave, convection, evaporation,
-conduction, respiration, metabolism) and returns the energy balance.
-
-# Arguments
-- `core_temperature`: Core temperature to evaluate
-- `organism::Organism`: Organism with body geometry and traits
-- `e`: Environment containing `environment_pars` and `environment_vars`
-
-# Returns
-NamedTuple with:
-- `heat_balance`: Net heat balance (should be zero at equilibrium)
-- `core_temperature`: Core temperature
-- `surface_temperature`: Surface temperature
-- `lung_temperature`: Lung temperature
-- `enbal`: Energy balance components
-- `masbal`: Mass balance components
-- `respiration_out`, `solar_out`, `longwave_gain_out`, `longwave_loss_out`, `convection_out`, `evaporation_out`: Detailed outputs
+Returns a NamedTuple:
+- `solar_flow` — absorbed solar radiation (W)
+- `longwave_flow_in` — incoming longwave radiation (W)
+- `longwave_flow_out` — outgoing longwave radiation (W)
+- `convection_heat_flow` — convective heat loss (W)
+- `convection_out` — full convection output (for mass transfer coefficients etc.)
+- `convection_area` — area used for convection (m²)
+- `conduction_area` — area in contact with substrate (m²)
+- `solar_out` — full solar output
+- `longwave_gain_out` — full longwave-in output
+- `longwave_loss_out` — full longwave-out output
 """
-function ectotherm end
-
-# A method dispatching on a `Model`
-#ectotherm(core_temperature, mod::Model, e) = ectotherm(core_temperature, stripparams(mod),
-#    stripparams(e.environment_pars), e.environment_vars)
-# A generic method that expands dispatch to include the insulation
-# this could be <:Ectotherm or <:Endotherm?
-#ectotherm(core_temperature, o::Organism, environment_pars, vars) = ectotherm(core_temperature, insulation(o), o,
-#    integumentpars(o), physiopars(o), thermoregpars(o), thermoregvars(o), environment_pars, vars)
-# A method for Naked organisms
-ectotherm(core_temperature, o::Organism, e) = ectotherm(core_temperature, insulation(body(o)), o, e)
-function ectotherm(core_temperature, insulation::Naked, o::Organism, e)
-    environment_pars = stripparams(e.environment_pars) # TODO make small function to get this, or extract all?
-    environment_vars = e.environment_vars # TODO make small function to get this, or extract all?
+function _radiative_convective_flows(surface_temperature, o::Organism, environment_pars, environment_vars)
     external_conduction = conduction_pars_external(o)
-    internal_conduction = conduction_pars_internal(o)
-    #conv = convection_pars(o)
     rad_pars = radiation_pars(o)
-    evap_pars = evaporation_pars(o)
-    hyd_pars = hydraulic_pars(o)
-    resp_pars = respiration_pars(o)
-    metab_pars = metabolism_pars(o)
 
-    # compute areas for exchange
     total_area = BiophysicalGeometry.total_area(o.body)
     convection_area = total_area * (1 - external_conduction.conduction_fraction)
     conduction_area = total_area * external_conduction.conduction_fraction
     silhouette_area = BiophysicalGeometry.silhouette_area(o.body, rad_pars.solar_orientation, environment_vars.zenith_angle)
 
-    # calculate heat flows
+    absorptivities = Absorptivities(rad_pars, environment_pars)
+    emissivities = Emissivities(rad_pars, environment_pars)
+    view_factors = ViewFactors(rad_pars.sky_view_factor, rad_pars.ground_view_factor, 0.0, 0.0)
+    solar_conditions = SolarConditions(environment_vars)
+    environmental_temps = EnvironmentTemperatures(environment_vars)
+
+    solar_out = solar(o.body, absorptivities, view_factors, solar_conditions, silhouette_area, conduction_area)
+    solar_flow = solar_out.solar_flow
+
+    longwave_gain_out = radiation_in(
+        o.body, view_factors, emissivities, environmental_temps;
+        conduction_fraction=external_conduction.conduction_fraction,
+    )
+    longwave_flow_in = longwave_gain_out.longwave_flow_in
+
+    longwave_loss_out = radiation_out(
+        o.body, view_factors, emissivities,
+        external_conduction.conduction_fraction,
+        surface_temperature, surface_temperature,
+    )
+    longwave_flow_out = longwave_loss_out.longwave_flow_out
+
+    convection_out = convection(;
+        body=o.body,
+        area=convection_area,
+        air_temperature=environment_vars.air_temperature,
+        surface_temperature,
+        wind_speed=environment_vars.wind_speed,
+        atmospheric_pressure=environment_vars.atmospheric_pressure,
+        fluid=environment_pars.fluid,
+        gas_fractions=environment_pars.gas_fractions,
+        convection_enhancement=environment_pars.convection_enhancement,
+    )
+    convection_heat_flow = convection_out.heat_flow
+
+    return (;
+        solar_flow, longwave_flow_in, longwave_flow_out,
+        convection_heat_flow, convection_out, convection_area, conduction_area,
+        solar_out, longwave_gain_out, longwave_loss_out,
+    )
+end
+
+"""
+    heat_balance(core_temperature, organism::Organism, e)
+
+Calculate heat balance for an organism (animal or leaf) at a given core temperature.
+
+Dispatches on `evaporation_pars(organism)` type:
+- `AnimalEvaporationParameters` → ectotherm/animal heat balance
+- `LeafEvaporationParameters`   → leaf heat balance (defined in `src/leaf/leaf.jl`)
+
+# Arguments
+- `core_temperature`: Core temperature to evaluate
+- `organism::Organism`: Organism with body geometry and traits
+- `e`: Environment containing `environment_pars` and `environment_vars`
+"""
+heat_balance(T, organism::Organism, e) =
+    heat_balance(T, evaporation_pars(organism), organism, e)
+
+# Animal/ectotherm dispatch
+heat_balance(T, ::AnimalEvaporationParameters, o::Organism, e) =
+    heat_balance(T, insulation(body(o)), o, e)
+
+function heat_balance(core_temperature, ::Naked, o::Organism, e)
+    environment_pars = stripparams(e.environment_pars)
+    environment_vars = e.environment_vars
+    internal_conduction = conduction_pars_internal(o)
+    evap_pars = evaporation_pars(o)
+    hyd_pars = hydraulic_pars(o)
+    resp_pars = respiration_pars(o)
+    metab_pars = metabolism_pars(o)
 
     # metabolism
     metabolic_heat_flow = metabolic_rate(metab_pars.model, o.body.shape.mass, core_temperature)
 
-    # respiration — clamp T_lung to [1°C, 50°C] matching NicheMapR RESP.f lines 154-160
+    # respiration
     T_lung_resp = clamp(core_temperature, u"K"(1.0u"°C"), u"K"(50.0u"°C"))
     rates = MetabolicRates(; metabolic=metabolic_heat_flow)
     atmos = AtmosphericConditions(environment_vars)
@@ -73,51 +117,21 @@ function ectotherm(core_temperature, insulation::Naked, o::Organism, e)
     respiration_heat_flow = respiration_out.respiration_heat_flow
     oxygen_flow = u"ml/hr"(Joules_to_O2(metabolic_heat_flow))
 
-    # net metabolic heat generation
+    # net metabolic heat generation → surface temperature
     net_metabolic_heat_production = metabolic_heat_flow - respiration_heat_flow
     specific_metabolic_heat_production = net_metabolic_heat_production / o.body.geometry.volume
-
-    # resultant surface and lung temperature
     (; surface_temperature, lung_temperature) = surface_and_lung_temperature(;
-        body=o.body, flesh_conductivity=internal_conduction.flesh_conductivity, specific_metabolic_heat_production, core_temperature
+        body=o.body,
+        flesh_conductivity=internal_conduction.flesh_conductivity,
+        specific_metabolic_heat_production,
+        core_temperature,
     )
 
-    # solar radiation
-    absorptivities = Absorptivities(rad_pars, environment_pars)
-    view_factors = ViewFactors(rad_pars.sky_view_factor, rad_pars.ground_view_factor, 0.0, 0.0)
-    solar_conditions = SolarConditions(environment_vars)
-    solar_out = solar(
-        o.body,
-        absorptivities,
-        view_factors,
-        solar_conditions,
-        silhouette_area,
-        conduction_area,
-    )
-    solar_flow = solar_out.solar_flow
-
-    # longwave in
-    emissivities = Emissivities(rad_pars, environment_pars)
-    environmental_temps = EnvironmentTemperatures(environment_vars)
-    longwave_gain_out = radiation_in(
-        o.body,
-        view_factors,
-        emissivities,
-        environmental_temps;
-        conduction_fraction=external_conduction.conduction_fraction,
-    )
-    longwave_flow_in = longwave_gain_out.longwave_flow_in
-
-    # longwave out
-    longwave_loss_out = radiation_out(
-        o.body,
-        view_factors,
-        emissivities,
-        external_conduction.conduction_fraction,
-        surface_temperature,  # dorsal_temperature
-        surface_temperature,  # ventral_temperature
-    )
-    longwave_flow_out = longwave_loss_out.longwave_flow_out
+    # radiative + convective flows
+    flows = _radiative_convective_flows(surface_temperature, o, environment_pars, environment_vars)
+    (; solar_flow, longwave_flow_in, longwave_flow_out, convection_heat_flow,
+       convection_out, convection_area, conduction_area,
+       solar_out, longwave_gain_out, longwave_loss_out) = flows
 
     # conduction
     conduction_flow = conduction(;
@@ -128,23 +142,9 @@ function ectotherm(core_temperature, insulation::Naked, o::Organism, e)
         substrate_conductivity=environment_vars.substrate_conductivity,
     )
 
-    # convection
-    convection_out = convection(;
-        body=o.body,
-        area=convection_area,
-        air_temperature=environment_vars.air_temperature,
-        surface_temperature,
-        wind_speed=environment_vars.wind_speed,
-        atmospheric_pressure=environment_vars.atmospheric_pressure,
-        fluid=environment_pars.fluid,
-        gas_fractions=environment_pars.gas_fractions,
-        convection_enhancement=environment_pars.convection_enhancement,
-    )
-    convection_heat_flow = convection_out.heat_flow
-
-    # evaporation — mouth opens when panting (NicheMapR PMOUTH: AEFF = (SKINW + PMOUTH)×area)
+    # evaporation — mouth opens when panting
     evap_eff = if resp_pars.pant > 1
-        EvaporationParameters(;
+        AnimalEvaporationParameters(;
             skin_wetness        = min(1.0, evap_pars.skin_wetness + resp_pars.mouth_fraction),
             insulation_wetness  = evap_pars.insulation_wetness,
             eye_fraction        = evap_pars.eye_fraction,
@@ -167,20 +167,29 @@ function ectotherm(core_temperature, insulation::Naked, o::Organism, e)
     evaporation_heat_flow = evaporation_out.evaporation_heat_flow
 
     # heat balance
-    heat_flow_in = solar_flow + longwave_flow_in + metabolic_heat_flow # energy in
-    heat_flow_out = longwave_flow_out + convection_heat_flow + evaporation_heat_flow + respiration_heat_flow + conduction_flow # energy out
-    #@assert heat_flow_in - heat_flow_out = 0.0u"W" # this must balance
-    heat_balance = heat_flow_in - heat_flow_out # this must balance
+    heat_flow_in  = solar_flow + longwave_flow_in + metabolic_heat_flow
+    heat_flow_out = longwave_flow_out + convection_heat_flow + evaporation_heat_flow +
+                    respiration_heat_flow + conduction_flow
+    heat_balance_val = heat_flow_in - heat_flow_out
 
-    enbal = (; solar_flow, longwave_flow_in, metabolic_heat_flow, respiration_heat_flow, evaporation_heat_flow, longwave_flow_out, convection_heat_flow, conduction_flow, heat_balance)
-    masbal = (; oxygen_flow, respiration_mass=respiration_out.respiration_mass, cutaneous_mass=evaporation_out.m_cut, eye_mass=evaporation_out.m_eyes)
-    (;
-        heat_balance,
+    energy_balance = (;
+        solar_flow, longwave_flow_in, metabolic_heat_flow, respiration_heat_flow,
+        evaporation_heat_flow, longwave_flow_out, convection_heat_flow, conduction_flow,
+        heat_balance=heat_balance_val,
+    )
+    mass_balance = (;
+        oxygen_flow,
+        respiration_mass=respiration_out.respiration_mass,
+        cutaneous_mass=evaporation_out.m_cut,
+        eye_mass=evaporation_out.m_eyes,
+    )
+    return (;
+        heat_balance=heat_balance_val,
         core_temperature,
         surface_temperature,
         lung_temperature,
-        enbal,
-        masbal,
+        energy_balance,
+        mass_balance,
         respiration_out,
         solar_out,
         longwave_gain_out,
@@ -189,8 +198,9 @@ function ectotherm(core_temperature, insulation::Naked, o::Organism, e)
         evaporation_out,
     )
 end
-function ectotherm(core_temperature, insulation::Fur, pars, organism, vars) # A method for organisms with fur
-    #....
+
+function heat_balance(core_temperature, ::Fur, o::Organism, e)
+    # stub for insulated animals — not yet implemented
 end
 
 """
@@ -207,52 +217,37 @@ balance equals zero.
 - `vars`: Environmental variables
 
 # Returns
-Full ectotherm output at the equilibrium core temperature.
+Full heat_balance output at the equilibrium core temperature.
 """
 function get_Tb(mod::Model, environment_pars, vars)
     air_temperature = vars.environment.air_temperature
     core_temperature = find_zero(
-        t -> ectotherm(t, mod, environment_pars, vars), (air_temperature - 40K, air_temperature + 100K), Bisection()
+        t -> heat_balance(t, mod, environment_pars, vars), (air_temperature - 40u"K", air_temperature + 100u"K"), Bisection()
     )
-    ectotherm(core_temperature, mod, environment_pars, vars)
+    heat_balance(core_temperature, mod, environment_pars, vars)
 end
 
-#flip2vectors(x) = (; (k => getfield.(x, k) for k in keys(x[1]))...)
+"""
+    solve_temperature(organism, environment; T_bracket=(270.0u"K", 370.0u"K")) → T
 
-#function ectotherm(core_temperature)
+Find the steady-state temperature of an organism (animal or leaf) by root-finding on
+`heat_balance`. Dispatch (animal vs leaf) is determined automatically by
+`evaporation_pars(organism)` type. Returns air temperature as fallback if root-finding fails.
 
-#    # compute areas for exchange
-#    A_convection = A_total * (1 - conduction_fraction)
-#    A_sil = silhouette_area(geometric_pars, zenith_angle)
-
-#    # calculate heat flows
-#    metab_out = metabolic_rate(geometric_pars.shape.mass, core_temperature, mass_normalisation, mass_exponent, thermal_sensitivity)
-#    metabolic_heat_flow = metab_out.metabolic_heat_flow
-#    resp_out = respiration_ectotherm(core_temperature, metabolic_heat_flow, fO2_extract, pant, rq, T_air, rh, elevation, P_atmos, fO2, fCO2, fN2)
-#    respiration_heat_flow = resp_out.respiration_heat_flow
-#    net_metabolic_heat_production = metabolic_heat_flow - respiration_heat_flow
-#    specific_metabolic_heat_production = net_metabolic_heat_production / geometric_pars.geometry.volume
-#    (; surface_temperature, lung_temperature) = surface_and_lung_temperature(geometric_pars, k_flesh, specific_metabolic_heat_production, core_temperature)
-#    #Q_norm = direct_flow / cos(zenith_angle)
-#    solar_out = solar(α_body_dorsal, α_body_ventral, A_sil, A_total, A_conduction, F_ground, F_sky, α_substrate, solar_flow, direct_flow, diffuse_flow)
-#    solar_flow = solar_out.solar_flow
-#    longwave_gain = radiation_in(A_total, A_conduction, F_sky, F_ground, ϵ_body_dorsal, ϵ_body_ventral, ϵ_ground, ϵ_sky, T_sky, T_ground)
-#    longwave_flow_in = longwave_gain.longwave_flow_in
-#    longwave_loss = radiation_out(T_surface, A_total, A_conduction, F_sky, F_ground, ϵ_body_dorsal, ϵ_body_ventral)
-#    longwave_flow_out = longwave_loss.longwave_flow_out
-#    conduction_flow = conduction(A_conduction, Le, T_surface, T_substrate, k_substrate)
-#    conv_out = convection(; body=geometric_pars, A_convection, T_air, T_surface, wind_speed, P_atmos, fluid)
-#    evap_out = evaporation(T_surface, ψ_org, skin_wetness, A_convection, conv_out.hd, eye_fraction, T_air, rh, P_atmos)
-#    convection_heat_flow = conv_out.convection_heat_flow
-#    evaporation_heat_flow = evap_out.evaporation_heat_flow
-
-#    # calculate balance
-#    heat_flow_in = solar_flow + longwave_flow_in + metabolic_heat_flow # energy in
-#    heat_flow_out = longwave_flow_out + convection_heat_flow + evaporation_heat_flow + respiration_heat_flow + conduction_flow # energy out
-#    #heat_flow_in - heat_flow_out # this must balance
-#    heat_balance = heat_flow_in - heat_flow_out # this must balance
-
-#    enbal = [solar_flow, longwave_flow_in, metabolic_heat_flow, respiration_heat_flow, evaporation_heat_flow, longwave_flow_out, convection_heat_flow, conduction_flow, heat_balance]
-#    masbal = [metab_out.oxygen_flow, resp_out.respiration_mass, evap_out.m_cut, evap_out.m_eyes]
-#    (; heat_balance, core_temperature, surface_temperature, lung_temperature, enbal, masbal, resp_out, solar_out, longwave_gain, longwave_loss, conv_out, evap_out)
-#end
+Eye/stomata state is a fixed parameter of the organism — no switching here.
+Temperature-triggered behavioural changes (eye opening, stomatal closure) belong in
+BiophysicalBehaviour.jl.
+"""
+function solve_temperature(organism, environment; T_bracket=(270.0u"K", 370.0u"K"))
+    lo = ustrip(u"K", T_bracket[1])
+    hi = ustrip(u"K", T_bracket[2])
+    try
+        T_sol = zbrent(
+            T -> ustrip(u"W", heat_balance(T * u"K", organism, environment).heat_balance),
+            lo, hi, 1e-3,
+        )
+        T_sol * u"K"
+    catch
+        environment.environment_vars.air_temperature
+    end
+end

--- a/src/ectotherm/ectotherm.jl
+++ b/src/ectotherm/ectotherm.jl
@@ -20,6 +20,7 @@ Returns a NamedTuple:
 function _radiative_convective_flows(surface_temperature, o::Organism, environment_pars, environment_vars)
     external_conduction = conduction_pars_external(o)
     rad_pars = radiation_pars(o)
+    conv_pars = convection_pars(o)
 
     total_area = BiophysicalGeometry.total_area(o.body)
     convection_area = total_area * (1 - external_conduction.conduction_fraction)
@@ -58,6 +59,7 @@ function _radiative_convective_flows(surface_temperature, o::Organism, environme
         fluid=environment_pars.fluid,
         gas_fractions=environment_pars.gas_fractions,
         convection_enhancement=environment_pars.convection_enhancement,
+        characteristic_dimension_formula=conv_pars.characteristic_dimension_formula,
     )
     convection_heat_flow = convection_out.heat_flow
 

--- a/src/ectotherm/lung_and_surface_temperature.jl
+++ b/src/ectotherm/lung_and_surface_temperature.jl
@@ -52,6 +52,16 @@ function surface_and_lung_temperature(shape::LeopardFrog, body::AbstractBody, fl
     return (; surface_temperature, lung_temperature)
 end
 
+function surface_and_lung_temperature(shape::Plate, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
+    # flat slab: half-thickness h = height/2 (shortest dimension)
+    # from plane-wall solution (Bird, Stewart & Lightfoot, Transport Phenomena)
+    h = body.geometry.length.height_skin / 2
+    surface_temperature = core_temperature - specific_metabolic_heat_production * h ^ 2 / (2 * flesh_conductivity)
+    lung_temperature = (specific_metabolic_heat_production * h ^ 2) / (4 * flesh_conductivity) + surface_temperature
+
+    return (; surface_temperature, lung_temperature)
+end
+
 function surface_and_lung_temperature(shape::Ellipsoid, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
     a = body.geometry.length[1] ^ 2
     b = body.geometry.length[2] ^ 2

--- a/src/ectotherm/lung_and_surface_temperature.jl
+++ b/src/ectotherm/lung_and_surface_temperature.jl
@@ -25,7 +25,7 @@ function surface_and_lung_temperature(body::AbstractBody, flesh_conductivity, sp
     surface_and_lung_temperature(shape(body), body, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
 end
 
-function surface_and_lung_temperature(shape::Cylinder, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
+function surface_and_lung_temperature(::Cylinder, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
     # cylinder: from P. 270 Bird, Stewart & Lightfoot. 1960. Transport Phenomena.
     flesh_radius = body.geometry.length[2]
     surface_temperature = core_temperature - specific_metabolic_heat_production * flesh_radius ^ 2 / (4 * flesh_conductivity)
@@ -34,7 +34,7 @@ function surface_and_lung_temperature(shape::Cylinder, body::AbstractBody, flesh
     return (; surface_temperature, lung_temperature)
 end
 
-function surface_and_lung_temperature(shape::DesertIguana, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
+function surface_and_lung_temperature(::Union{DesertIguana,LeopardFrog}, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
     # cylinder: from P. 270 Bird, Stewart & Lightfoot. 1960. Transport Phenomena.
     flesh_radius = body.geometry.length[1]
     surface_temperature = core_temperature - specific_metabolic_heat_production * flesh_radius ^ 2 / (4 * flesh_conductivity)
@@ -43,16 +43,7 @@ function surface_and_lung_temperature(shape::DesertIguana, body::AbstractBody, f
     return (; surface_temperature, lung_temperature)
 end
 
-function surface_and_lung_temperature(shape::LeopardFrog, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
-    # cylinder: from P. 270 Bird, Stewart & Lightfoot. 1960. Transport Phenomena.
-    flesh_radius = body.geometry.length[1]
-    surface_temperature = core_temperature - specific_metabolic_heat_production * flesh_radius ^ 2 / (4 * flesh_conductivity)
-    lung_temperature = (specific_metabolic_heat_production * flesh_radius ^ 2) / (8 * flesh_conductivity) + surface_temperature
-
-    return (; surface_temperature, lung_temperature)
-end
-
-function surface_and_lung_temperature(shape::Plate, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
+function surface_and_lung_temperature(::Plate, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
     # flat slab: half-thickness h = height/2 (shortest dimension)
     # from plane-wall solution (Bird, Stewart & Lightfoot, Transport Phenomena)
     h = body.geometry.length.height_skin / 2
@@ -62,7 +53,7 @@ function surface_and_lung_temperature(shape::Plate, body::AbstractBody, flesh_co
     return (; surface_temperature, lung_temperature)
 end
 
-function surface_and_lung_temperature(shape::Ellipsoid, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
+function surface_and_lung_temperature(::Ellipsoid, body::AbstractBody, flesh_conductivity, specific_metabolic_heat_production, core_temperature)
     a = body.geometry.length[1] ^ 2
     b = body.geometry.length[2] ^ 2
     c = body.geometry.length[3] ^ 2

--- a/src/endotherm/compressed_radiant_temperature.jl
+++ b/src/endotherm/compressed_radiant_temperature.jl
@@ -18,7 +18,7 @@ at the compressed insulation-substrate interface.
 
 # Returns
 NamedTuple with:
-- `cf1`: Compression factor coefficient
+- `compression_fraction`: Compression factor coefficient
 - `compressed_insulation_temperature`: Temperature at compressed insulation interface
 """
 function compressed_radiant_temperature(;
@@ -47,19 +47,21 @@ function compressed_radiant_temperature(
     core_temperature,
     substrate_temperature,
 )
-    r_skin = get_r_skin(body)
-    r_flesh = get_r_flesh(body)
+    volume = flesh_volume(body)
+    length = body.geometry.length.length_skin
+    r_skin = skin_radius(body)
+    r_flesh = flesh_radius(body)
     r_compressed = r_skin + insulation_pars.depth_compressed
 
-    cf1 = (2 * π * insulation.conductivity_compressed * length) / (log(r_compressed / r_skin))
-    dv5 =
+    compression_fraction = (2 * π * insulation.conductivity_compressed * length) / (log(r_compressed / r_skin))
+    geometric_divisor =
         1 +
-        ((cf1 * r_flesh^2) / (4 * conductivities.flesh * volume)) +
-        ((cf1 * r_flesh^2) / (2 * conductivities.fat * volume)) * log(r_skin / RFLESH)
-    compressed_insulation_temperature_calc1 = (cf1 / dv5) * core_temperature + conductance_coefficient * substrate_temperature
-    compressed_insulation_temperature_calc2 = conductance_coefficient + cf1 / dv5
+        ((compression_fraction * r_flesh^2) / (4 * conductivities.flesh * volume)) +
+        ((compression_fraction * r_flesh^2) / (2 * conductivities.fat * volume)) * log(r_skin / r_flesh)
+    compressed_insulation_temperature_calc1 = (compression_fraction / geometric_divisor) * core_temperature + conductance_coefficient * substrate_temperature
+    compressed_insulation_temperature_calc2 = conductance_coefficient + compression_fraction / geometric_divisor
     compressed_insulation_temperature = compressed_insulation_temperature_calc1 / compressed_insulation_temperature_calc2
-    return (; cf1, compressed_insulation_temperature)
+    return (; compression_fraction, compressed_insulation_temperature)
 end
 
 function compressed_radiant_temperature(
@@ -73,20 +75,21 @@ function compressed_radiant_temperature(
     core_temperature,
     substrate_temperature,
 )
-    r_skin = get_r_skin(body)
-    r_flesh = get_r_flesh(body)
+    volume = flesh_volume(body)
+    r_skin = skin_radius(body)
+    r_flesh = flesh_radius(body)
     r_compressed = r_skin + insulation_pars.depth_compressed
 
-    cf1 = (4 * π * insulation.conductivity_compressed * r_compressed) / (r_compressed - r_skin)
-    dv5 =
+    compression_fraction = (4 * π * insulation.conductivity_compressed * r_compressed) / (r_compressed - r_skin)
+    geometric_divisor =
         1 +
-        ((cf1 * r_flesh^2.0) / (6 * conductivities.flesh * volume)) +
-        ((cf1 * r_flesh^3) / (3 * conductivities.fat * volume)) *
-        ((r_skin - r_flesh) / (r_skin - r_flesh))
-    compressed_insulation_temperature_calc1 = (cf1 / dv5) * core_temperature + conductance_coefficient * substrate_temperature
-    compressed_insulation_temperature_calc2 = conductance_coefficient + cf1 / dv5
+        ((compression_fraction * r_flesh^2.0) / (6 * conductivities.flesh * volume)) +
+        ((compression_fraction * r_flesh^3) / (3 * conductivities.fat * volume)) *
+        ((r_skin - r_flesh) / (r_flesh * r_skin))
+    compressed_insulation_temperature_calc1 = (compression_fraction / geometric_divisor) * core_temperature + conductance_coefficient * substrate_temperature
+    compressed_insulation_temperature_calc2 = conductance_coefficient + compression_fraction / geometric_divisor
     compressed_insulation_temperature = compressed_insulation_temperature_calc1 / compressed_insulation_temperature_calc2
-    return (; cf1, compressed_insulation_temperature)
+    return (; compression_fraction, compressed_insulation_temperature)
 end
 
 function compressed_radiant_temperature(
@@ -129,16 +132,16 @@ function compressed_radiant_temperature(
     bl_compressed = b_semi_minor + insulation_pars.depth_compressed
     bg = min(b_semi_minor, b_semi_minor_flesh)
 
-    cf1 =
+    compression_fraction =
         (3 * insulation.conductivity_compressed * volume * bl_compressed * bs) /
         ((((3 * ssqg)^0.5)^3) * (bl - bs))
-    dv5 =
+    geometric_divisor =
         1 +
-        ((cf1 * ssqg) / (2 * conductivities.flesh * volume)) +
-        ((cf1 * (((3 * ssqg)^0.5)^3)) / (3 * conductivities.fat * volume)) * ((bs - bg) / (bs * bg))
-    compressed_insulation_temperature_calc1 = (cf1 / dv5) * core_temperature + conductance_coefficient * substrate_temperature
-    compressed_insulation_temperature_calc2 = conductance_coefficient + cf1 / dv5
+        ((compression_fraction * ssqg) / (2 * conductivities.flesh * volume)) +
+        ((compression_fraction * (((3 * ssqg)^0.5)^3)) / (3 * conductivities.fat * volume)) * ((bs - bg) / (bs * bg))
+    compressed_insulation_temperature_calc1 = (compression_fraction / geometric_divisor) * core_temperature + conductance_coefficient * substrate_temperature
+    compressed_insulation_temperature_calc2 = conductance_coefficient + compression_fraction / geometric_divisor
     compressed_insulation_temperature = compressed_insulation_temperature_calc1 / compressed_insulation_temperature_calc2
 
-    return (; cf1, compressed_insulation_temperature)
+    return (; compression_fraction, compressed_insulation_temperature)
 end

--- a/src/endotherm/endotherm.jl
+++ b/src/endotherm/endotherm.jl
@@ -384,9 +384,9 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
     skin_temperature = skin_temperature_dorsal * dmult + skin_temperature_ventral * vmult
     insulation_temperature = insulation_temperature_dorsal * dmult + insulation_temperature_ventral * vmult
     if o.body.shape isa Sphere
-        shape_b = 1.0
+        aspect_ratio_b = 1.0
     else
-        shape_b = o.body.shape.b
+        aspect_ratio_b = o.body.shape.aspect_ratio_b
     end
     thermoregulation = (;
         metab_pars.core_temperature,
@@ -397,7 +397,7 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
         skin_temperature_ventral,
         insulation_temperature_dorsal,
         insulation_temperature_ventral,
-        shape_b,
+        aspect_ratio_b,
         pant=resp_pars.pant,
         skin_wetness=evap_pars.skin_wetness,
         flesh_conductivity=internal_conduction.flesh_conductivity,

--- a/src/endotherm/endotherm.jl
+++ b/src/endotherm/endotherm.jl
@@ -421,7 +421,7 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
         ground_view_factor=ground_factor_ref,
         volume,
         volume_flesh,
-        characteristic_dimension=geometry_pars.geometry.characteristic_dimension,
+        characteristic_dimension=characteristic_dimension(VolumeCubeRoot(), geometry_pars),
         fat_mass,
         geometry_pars.geometry.length...,
     )

--- a/src/endotherm/endotherm.jl
+++ b/src/endotherm/endotherm.jl
@@ -60,7 +60,7 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
     fibres = insulation.fibres
     # if no insulation, reset bare_skin_fraction if necessary
     if insulation.insulation_test <= 0.0u"m" && evap_pars.bare_skin_fraction < 1.0
-        evap_temp = EvaporationParameters(;
+        evap_temp = AnimalEvaporationParameters(;
             skin_wetness=evap_pars.skin_wetness,
             insulation_wetness=evap_pars.insulation_wetness,
             eye_fraction=evap_pars.eye_fraction,

--- a/src/endotherm/endotherm.jl
+++ b/src/endotherm/endotherm.jl
@@ -248,7 +248,7 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
                 resp_pars,
                 resp_atmos,
                 geometry_pars.shape.mass,
-                lung_temperature,
+                exit_air_temperature,
                 environment_vars.air_temperature;
                 gas_fractions=environment_pars.gas_fractions,
                 O2conversion=Kleiber1961(),

--- a/src/endotherm/heat_balance.jl
+++ b/src/endotherm/heat_balance.jl
@@ -78,27 +78,11 @@ function heat_balance(
     area_evaporation = evaporation_area(body)
     area_convection  = total_area * (1 - conduction_fraction)
 
-    # -------------------------------------------------------------------------
     # Recompute temperature-dependent insulation conductivity at current T_skin, T_ins.
-    # This mirrors the per-iteration update in solve_with_insulation! and ensures
-    # the function is differentiable with respect to the temperature decision variables.
-    # -------------------------------------------------------------------------
-    insulation_temp_mean = T_ins * 0.7 + T_skin * 0.3
-    air_k = dry_air_properties(insulation_temp_mean).thermal_conductivity
-    side_depth = getproperty(insulation.fibres, side).depth
-    side_fibres = setproperties(getproperty(insulation_pars, side); depth = side_depth)
-    side_thermal = insulation_thermal_conductivity(side_fibres, air_k)
-    effective_conductivity = side_thermal.effective_conductivity
-
-    absorption_coefficient = getproperty(insulation.absorption_coefficients, side)
-    approx_radiant_temperature = T_skin * (1 - longwave_depth_fraction) + T_ins * longwave_depth_fraction
-    radiative_conductivity = (16 * σ * approx_radiant_temperature^3) / (3 * absorption_coefficient)
-    insulation_conductivity = effective_conductivity + radiative_conductivity
-
-    # ThermalConductivities with k_flesh override (vasodilation decision variable)
+    # Mirrors the per-iteration update in solve_with_insulation! for differentiability.
+    (; insulation_conductivity, effective_conductivity) = _insulation_conductivity(
+        insulation, insulation_pars, side, T_ins, T_skin, longwave_depth_fraction, σ)
     conductivities = ThermalConductivities(k_flesh, fat_conductivity, insulation_conductivity)
-
-    # Update insulation struct with recomputed compressed conductivity (used in radiant_temperature)
     insulation_updated = setproperties(insulation; conductivity_compressed = effective_conductivity)
 
     # -------------------------------------------------------------------------
@@ -156,37 +140,20 @@ function heat_balance(
     conductances = radiant_temp_result.conductances
     divisors     = radiant_temp_result.divisors
 
-    # -------------------------------------------------------------------------
-    # Insulation surface evaporation (if insulation is wet — conditional is on
-    # fixed parameters, so not inside the differentiable path)
-    # -------------------------------------------------------------------------
-    insulation_evaporation_heat_flow = if insulation_wetness > 0 && insulation.insulation_test > 0.0u"m"
-        evap_pars_ins = AnimalEvaporationParameters(;
-            skin_wetness = insulation_wetness,
-            eye_fraction = 0.0,
-            bare_skin_fraction = 1.0,
-        )
-        mass_ins = TransferCoefficients(conv.mass.combined, conv.mass.combined, conv.mass.forced)
-        evaporation(
-            evap_pars_ins, mass_ins, atmos_local, area_convection, T_ins, air_temperature;
-            gas_fractions,
-        ).evaporation_heat_flow
-    else
-        0.0u"W"
-    end
+    # Insulation surface evaporation (conditional on fixed params, outside differentiable path)
+    insulation_evaporation_heat_flow = _insulation_evaporation(
+        conv, atmos_local, area_convection, T_ins, air_temperature,
+        insulation_wetness, insulation.insulation_test; gas_fractions)
 
     # -------------------------------------------------------------------------
     # Radiation exchange (coefficients linearised at T_rad, flows use T_rad)
     # -------------------------------------------------------------------------
-    sky_radiation_coeff =
-        area_convection * view_factors.sky * 4 * ϵ_body * σ * ((T_rad + sky_temperature) / 2)^3
-    bush_radiation_coeff =
-        area_convection * view_factors.bush * 4 * ϵ_body * σ * ((T_rad + bush_temperature) / 2)^3
-    vegetation_radiation_coeff =
-        area_convection * view_factors.vegetation * 4 * ϵ_body * σ *
-        ((T_rad + vegetation_temperature) / 2)^3
-    ground_radiation_coeff =
-        area_convection * view_factors.ground * 4 * ϵ_body * σ * ((T_rad + ground_temperature) / 2)^3
+    _rc = _radiation_coefficients(area_convection, view_factors, ϵ_body, σ, T_rad,
+        sky_temperature, bush_temperature, vegetation_temperature, ground_temperature)
+    sky_radiation_coeff        = _rc.sky
+    bush_radiation_coeff       = _rc.bush
+    vegetation_radiation_coeff = _rc.vegetation
+    ground_radiation_coeff     = _rc.ground
 
     sky_radiation_flow        = sky_radiation_coeff        * (T_rad - sky_temperature)
     bush_radiation_flow       = bush_radiation_coeff       * (T_rad - bush_temperature)

--- a/src/endotherm/heat_balance.jl
+++ b/src/endotherm/heat_balance.jl
@@ -1,0 +1,292 @@
+"""
+    heat_balance(T_core, T_skin, T_ins, Q_gen; ...)
+
+Compute endotherm heat budget residuals at explicitly given temperatures and metabolic rate.
+
+Non-iterative: all state variables are explicit inputs. Returns three residuals that
+equal zero at a valid steady-state heat balance, making this function suitable as an
+IPOPT/NLP constraint function differentiable via ForwardDiff.
+
+This extends the existing `heat_balance(T_body, organism, e)` ectotherm dispatch with
+a multi-argument endotherm method. Decision variables are positional arguments; fixed
+parameters come from keyword arguments.
+
+Designed to work per body side (`:dorsal` or `:ventral`) using the same pre-packed
+`geometry_vars` and `environment_vars` structures that `solve_temperatures` accepts.
+
+# Arguments
+- `T_core`: Core body temperature (K) — setpoint or decision variable
+- `T_skin`: Skin surface temperature (K) — decision variable (replaces iterative solve)
+- `T_ins`: Insulation surface (fur-air interface) temperature (K) — decision variable
+- `Q_gen`: Metabolic heat generation rate (W) — decision variable (replaces zbrent)
+
+# Keywords
+- `body::AbstractBody`: Body geometry (shape + composite insulation)
+- `insulation_pars::InsulationParameters`: Insulation parameters (fibre properties, depths)
+- `insulation::InsulationProperties`: Precomputed insulation properties; temperature-sensitive
+  conductivities are recomputed internally from `T_skin` and `T_ins`
+- `geometry_vars::GeometryVariables`: Geometric variables (side, conductance coefficient, etc.)
+- `environment_vars::NamedTuple`: Packed environment (temperatures, view factors, atmos, solar)
+- `traits::NamedTuple`: Fixed organism traits (fat conductivity, emissivity, evap fractions)
+- `resp_pars`: Respiration parameters
+- `minimum_metabolic_heat`: Minimum metabolic rate floor (W); defaults to zero
+- `k_flesh`: Flesh thermal conductivity (W/m/K); overrides `traits.flesh_conductivity`
+- `pant`: Panting multiplier; overrides `resp_pars.pant`
+- `skin_wetness`: Skin wetness fraction; overrides `traits.skin_wetness`
+
+# Returns
+NamedTuple with heat fluxes and three residuals:
+- `solar_heat_flow`, `convection_heat_flow`, `radiation_heat_flow`, `conduction_heat_flow`
+- `skin_evaporation_heat_flow`, `insulation_evaporation_heat_flow`, `respiration_heat_flow`
+- `net_metabolic_heat_internal`: heat conducted through flesh/fat layer
+- `sky_radiation_flow`, `bush_radiation_flow`, `vegetation_radiation_flow`, `ground_radiation_flow`
+- `residual_energy_balance` (W): Q_gen + Q_solar − Q_resp − Q_evap − Q_conv − Q_rad − Q_cond = 0
+- `residual_internal_conduction` (W): (Q_gen − Q_resp) − net_metabolic_heat_internal = 0
+- `residual_skin_temperature` (K): T_skin − T_skin_from_mean_skin_temperature = 0
+"""
+function heat_balance(
+    T_core, T_skin, T_ins, Q_gen;
+    body::AbstractBody,
+    insulation_pars::InsulationParameters,
+    insulation::InsulationProperties,
+    geometry_vars::GeometryVariables,
+    environment_vars::NamedTuple,
+    traits::NamedTuple,
+    resp_pars,
+    minimum_metabolic_heat = zero(Q_gen),
+    k_flesh = traits.flesh_conductivity,
+    pant = resp_pars.pant,
+    skin_wetness = traits.skin_wetness,
+)
+    (; side, conductance_coefficient, conduction_fraction, longwave_depth_fraction) = geometry_vars
+    (;
+        temperature, view_factors, atmos, fluid, solar_flow, gas_fractions, convection_enhancement,
+    ) = environment_vars
+    air_temperature     = temperature.air
+    sky_temperature     = temperature.sky
+    ground_temperature  = temperature.ground
+    vegetation_temperature = temperature.vegetation
+    bush_temperature    = temperature.bush
+    substrate_temperature  = temperature.substrate
+    (; relative_humidity, wind_speed, atmospheric_pressure) = atmos
+    (; fat_conductivity, ϵ_body, insulation_wetness, bare_skin_fraction, eye_fraction) = traits
+
+    σ = Unitful.uconvert(u"W/m^2/K^4", Unitful.σ)
+
+    # Body areas
+    total_area      = BiophysicalGeometry.total_area(body)
+    area_evaporation = evaporation_area(body)
+    area_convection  = total_area * (1 - conduction_fraction)
+
+    # -------------------------------------------------------------------------
+    # Recompute temperature-dependent insulation conductivity at current T_skin, T_ins.
+    # This mirrors the per-iteration update in solve_with_insulation! and ensures
+    # the function is differentiable with respect to the temperature decision variables.
+    # -------------------------------------------------------------------------
+    insulation_temp_mean = T_ins * 0.7 + T_skin * 0.3
+    air_k = dry_air_properties(insulation_temp_mean).thermal_conductivity
+    side_depth = getproperty(insulation.fibres, side).depth
+    side_fibres = setproperties(getproperty(insulation_pars, side); depth = side_depth)
+    side_thermal = insulation_thermal_conductivity(side_fibres, air_k)
+    effective_conductivity = side_thermal.effective_conductivity
+
+    absorption_coefficient = getproperty(insulation.absorption_coefficients, side)
+    approx_radiant_temperature = T_skin * (1 - longwave_depth_fraction) + T_ins * longwave_depth_fraction
+    radiative_conductivity = (16 * σ * approx_radiant_temperature^3) / (3 * absorption_coefficient)
+    insulation_conductivity = effective_conductivity + radiative_conductivity
+
+    # ThermalConductivities with k_flesh override (vasodilation decision variable)
+    conductivities = ThermalConductivities(k_flesh, fat_conductivity, insulation_conductivity)
+
+    # Update insulation struct with recomputed compressed conductivity (used in radiant_temperature)
+    insulation_updated = setproperties(insulation; conductivity_compressed = effective_conductivity)
+
+    # -------------------------------------------------------------------------
+    # Convection at insulation surface (pure function of T_ins)
+    # -------------------------------------------------------------------------
+    conv = convection(;
+        body,
+        area = area_convection,
+        air_temperature,
+        surface_temperature = T_ins,
+        wind_speed,
+        atmospheric_pressure,
+        fluid,
+        gas_fractions,
+        convection_enhancement,
+    )
+    heat_transfer_coefficient = conv.heat.combined
+
+    # -------------------------------------------------------------------------
+    # Skin evaporation (uses mass transfer coefficients from convection call)
+    # -------------------------------------------------------------------------
+    evap_pars_skin = AnimalEvaporationParameters(; skin_wetness, eye_fraction, bare_skin_fraction)
+    atmos_local = AtmosphericConditions(relative_humidity, wind_speed, atmospheric_pressure)
+    skin_evaporation_heat_flow = evaporation(
+        evap_pars_skin,
+        conv.mass,
+        atmos_local,
+        area_evaporation,
+        T_skin,
+        air_temperature;
+        gas_fractions,
+    ).evaporation_heat_flow
+
+    # -------------------------------------------------------------------------
+    # Radiant temperature at insulation depth (shape-dispatched pure function).
+    # Provides T_rad for radiation coefficients, compressed_insulation_temperature
+    # for conduction, and conductances/divisors for mean_skin_temperature.
+    # -------------------------------------------------------------------------
+    org_temps = OrganismTemperatures(T_core, T_skin, T_ins)
+    radiant_temp_result = radiant_temperature(;
+        body,
+        insulation = insulation_updated,
+        insulation_pars,
+        org_temps,
+        conductivities,
+        side,
+        conductance_coefficient,
+        longwave_depth_fraction,
+        conduction_fraction,
+        evaporation_flow = skin_evaporation_heat_flow,
+        substrate_temperature,
+    )
+    T_rad = radiant_temp_result.radiant_temperature
+    compressed_insulation_temperature = radiant_temp_result.compressed_insulation_temperature
+    conductances = radiant_temp_result.conductances
+    divisors     = radiant_temp_result.divisors
+
+    # -------------------------------------------------------------------------
+    # Insulation surface evaporation (if insulation is wet — conditional is on
+    # fixed parameters, so not inside the differentiable path)
+    # -------------------------------------------------------------------------
+    insulation_evaporation_heat_flow = if insulation_wetness > 0 && insulation.insulation_test > 0.0u"m"
+        evap_pars_ins = AnimalEvaporationParameters(;
+            skin_wetness = insulation_wetness,
+            eye_fraction = 0.0,
+            bare_skin_fraction = 1.0,
+        )
+        mass_ins = TransferCoefficients(conv.mass.combined, conv.mass.combined, conv.mass.forced)
+        evaporation(
+            evap_pars_ins, mass_ins, atmos_local, area_convection, T_ins, air_temperature;
+            gas_fractions,
+        ).evaporation_heat_flow
+    else
+        0.0u"W"
+    end
+
+    # -------------------------------------------------------------------------
+    # Radiation exchange (coefficients linearised at T_rad, flows use T_rad)
+    # -------------------------------------------------------------------------
+    sky_radiation_coeff =
+        area_convection * view_factors.sky * 4 * ϵ_body * σ * ((T_rad + sky_temperature) / 2)^3
+    bush_radiation_coeff =
+        area_convection * view_factors.bush * 4 * ϵ_body * σ * ((T_rad + bush_temperature) / 2)^3
+    vegetation_radiation_coeff =
+        area_convection * view_factors.vegetation * 4 * ϵ_body * σ *
+        ((T_rad + vegetation_temperature) / 2)^3
+    ground_radiation_coeff =
+        area_convection * view_factors.ground * 4 * ϵ_body * σ * ((T_rad + ground_temperature) / 2)^3
+
+    sky_radiation_flow        = sky_radiation_coeff        * (T_rad - sky_temperature)
+    bush_radiation_flow       = bush_radiation_coeff       * (T_rad - bush_temperature)
+    vegetation_radiation_flow = vegetation_radiation_coeff * (T_rad - vegetation_temperature)
+    ground_radiation_flow     = ground_radiation_coeff     * (T_rad - ground_temperature)
+    radiation_heat_flow =
+        sky_radiation_flow + bush_radiation_flow + vegetation_radiation_flow + ground_radiation_flow
+
+    # -------------------------------------------------------------------------
+    # Convection flow (at outer insulation surface T_ins)
+    # -------------------------------------------------------------------------
+    convection_heat_flow = heat_transfer_coefficient * area_convection * (T_ins - air_temperature)
+
+    # -------------------------------------------------------------------------
+    # Conduction flow to substrate (via compressed insulation temperature)
+    # -------------------------------------------------------------------------
+    conduction_heat_flow = u"W"(conductance_coefficient * (compressed_insulation_temperature - substrate_temperature))
+
+    # -------------------------------------------------------------------------
+    # Net metabolic heat conducted through flesh and fat (existing shape-dispatched function)
+    # -------------------------------------------------------------------------
+    net_metabolic_heat_internal = net_metabolic_heat(;
+        body,
+        conductivities,
+        core_temperature = T_core,
+        skin_temperature = T_skin,
+    )
+
+    # -------------------------------------------------------------------------
+    # Skin temperature from the insulation-side calculation.
+    # Combines core-side (skin_temperature_calc1) and insulation-side
+    # (skin_temperature_calc2) into a mean; both equal T_skin at convergence.
+    # -------------------------------------------------------------------------
+    environment_flow = radiation_heat_flow + convection_heat_flow + conduction_heat_flow +
+                       insulation_evaporation_heat_flow - solar_flow
+    mean_skin_temp_result = mean_skin_temperature(;
+        body,
+        insulation = insulation_updated,
+        insulation_pars,
+        conductivities,
+        conductances,
+        conduction_fraction,
+        environment_flow,
+        skin_evaporation_flow = skin_evaporation_heat_flow,
+        core_temperature = T_core,
+        calculated_insulation_temperature = T_ins,
+        compressed_insulation_temperature,
+    )
+    T_skin_from_heat_balance = mean_skin_temp_result.mean_skin_temperature
+
+    # -------------------------------------------------------------------------
+    # Respiration with pant override (pure function of Q_gen and temperatures)
+    # -------------------------------------------------------------------------
+    lung_temperature = (T_core + T_skin) / 2
+    resp_pars_effective = setproperties(resp_pars; pant)
+    resp_out = respiration(
+        MetabolicRates(; metabolic = Q_gen, sum = Q_gen, minimum = minimum_metabolic_heat),
+        resp_pars_effective,
+        atmos_local,
+        body.shape.mass,
+        lung_temperature,
+        air_temperature;
+        gas_fractions,
+        O2conversion = Kleiber1961(),
+    )
+    respiration_heat_flow = uconvert(u"W", resp_out.respiration_heat_flow)
+
+    # =========================================================================
+    # Residuals — each equals zero at a valid steady-state heat balance
+    # =========================================================================
+
+    # Global power balance: total generation = total losses
+    residual_energy_balance = Q_gen + solar_flow -
+        respiration_heat_flow -
+        skin_evaporation_heat_flow - insulation_evaporation_heat_flow -
+        convection_heat_flow - radiation_heat_flow - conduction_heat_flow
+
+    # Internal conduction: net metabolic heat (after respiration) must match
+    # what the flesh/fat layer conducts given T_core and T_skin
+    residual_internal_conduction = (Q_gen - respiration_heat_flow) - net_metabolic_heat_internal
+
+    # Skin temperature: T_skin must be consistent with both the core-side and
+    # insulation-side estimates from mean_skin_temperature (units: K)
+    residual_skin_temperature = T_skin - T_skin_from_heat_balance
+
+    return (;
+        solar_heat_flow = solar_flow,
+        convection_heat_flow,
+        radiation_heat_flow,
+        conduction_heat_flow,
+        skin_evaporation_heat_flow,
+        insulation_evaporation_heat_flow,
+        respiration_heat_flow,
+        net_metabolic_heat_internal,
+        sky_radiation_flow,
+        bush_radiation_flow,
+        vegetation_radiation_flow,
+        ground_radiation_flow,
+        residual_energy_balance,
+        residual_internal_conduction,
+        residual_skin_temperature,
+    )
+end

--- a/src/endotherm/insulation_radiant_temperature.jl
+++ b/src/endotherm/insulation_radiant_temperature.jl
@@ -120,12 +120,12 @@ function insulation_radiant_temperature(
 
     if longwave_depth_fraction < 1
         ins_calc1 =
-            coeffs.sky * env_temps.sky + coeffs.bush * env_temps.bush + coeffs.vegetation * env_temps.vegetation + coeffs.ground * env_temps.ground -
+            coeffs.sky * T.sky + coeffs.bush * T.bush + coeffs.vegetation * T.vegetation + coeffs.ground * T.ground -
             (coeffs.sky + coeffs.bush + coeffs.vegetation + coeffs.ground) *
             ((numerator_divisor / radiative_divisor) + ((compressed_insulation_temperature * compressed_conductance) / radiative_divisor))
-        ins_calc2 = ((2 * π * LEN) / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
+        ins_calc2 = ((2 * π * length) / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc3 =
-            heat_transfer_coefficient * area_convection * env_temps.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * env_temps.substrate -
+            heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
             (2 * π * length * uncompressed_conductance) / geometric_divisor +
@@ -149,10 +149,10 @@ function insulation_radiant_temperature(
         )
     else
         ins_calc1 =
-            coeffs.sky * env_temps.sky + coeffs.bush * env_temps.bush + coeffs.vegetation * env_temps.vegetation + coeffs.ground * env_temps.ground
+            coeffs.sky * T.sky + coeffs.bush * T.bush + coeffs.vegetation * T.vegetation + coeffs.ground * T.ground
         ins_calc2 = ((2 * π * length) / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc3 =
-            heat_transfer_coefficient * area_convection * env_temps.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * env_temps.substrate -
+            heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
             (2 * π * length * uncompressed_conductance) / geometric_divisor +
@@ -212,11 +212,11 @@ function insulation_radiant_temperature(
     if longwave_depth_fraction < 1
         ins_calc1 = ((4 * π * r_skin) / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc2 =
-            coeffs.sky * env_temps.sky + coeffs.bush * env_temps.bush + coeffs.vegetation * env_temps.vegetation + coeffs.ground * env_temps.ground -
+            coeffs.sky * T.sky + coeffs.bush * T.bush + coeffs.vegetation * T.vegetation + coeffs.ground * T.ground -
             (coeffs.sky + coeffs.bush + coeffs.vegetation + coeffs.ground) *
             ((numerator_divisor / radiative_divisor) + ((compressed_insulation_temperature * compressed_conductance) / radiative_divisor))
         ins_calc3 =
-            heat_transfer_coefficient * area_convection * env_temps.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * env_temps.substrate -
+            heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
             (4 * π * r_skin * uncompressed_conductance) / geometric_divisor +
@@ -241,9 +241,9 @@ function insulation_radiant_temperature(
     else
         ins_calc1 = ((4 * π * r_skin) / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc2 =
-            coeffs.sky * env_temps.sky + coeffs.bush * env_temps.bush + coeffs.vegetation * env_temps.vegetation + coeffs.ground * env_temps.ground
+            coeffs.sky * T.sky + coeffs.bush * T.bush + coeffs.vegetation * T.vegetation + coeffs.ground * T.ground
         ins_calc3 =
-            heat_transfer_coefficient * area_convection * env_temps.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * env_temps.substrate -
+            heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
             (4 * π * r_skin * uncompressed_conductance) / geometric_divisor +
@@ -316,14 +316,14 @@ function insulation_radiant_temperature(
 
     if longwave_depth_fraction < 1
         ins_calc1 =
-            coeffs.sky * env_temps.sky + coeffs.bush * env_temps.bush + coeffs.vegetation * env_temps.vegetation + coeffs.ground * env_temps.ground -
+            coeffs.sky * T.sky + coeffs.bush * T.bush + coeffs.vegetation * T.vegetation + coeffs.ground * T.ground -
             (coeffs.sky + coeffs.bush + coeffs.vegetation + coeffs.ground) *
             ((numerator_divisor / radiative_divisor) + ((compressed_insulation_temperature * compressed_conductance) / radiative_divisor))
         ins_calc2 =
             ((3 * volume * bs) / ((((3 * ssqg)^0.5)^3) * geometric_divisor)) *
             (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc3 =
-            heat_transfer_coefficient * area_convection * env_temps.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * env_temps.substrate -
+            heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
             (3 * volume * bs * uncompressed_conductance) / ((((3 * ssqg)^0.5)^3) * geometric_divisor) +
@@ -344,9 +344,9 @@ function insulation_radiant_temperature(
             ((3 * volume * bs) / ((((3 * ssqg)^0.5)^3) * geometric_divisor)) *
             (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc2 =
-            coeffs.sky * env_temps.sky + coeffs.bush * env_temps.bush + coeffs.vegetation * env_temps.vegetation + coeffs.ground * env_temps.ground
+            coeffs.sky * T.sky + coeffs.bush * T.bush + coeffs.vegetation * T.vegetation + coeffs.ground * T.ground
         ins_calc3 =
-            heat_transfer_coefficient * area_convection * env_temps.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * env_temps.substrate -
+            heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
             (3 * volume * bs * uncompressed_conductance) / ((((3 * ssqg)^0.5)^3) * geometric_divisor) +

--- a/src/endotherm/skin_and_insulation_temperature.jl
+++ b/src/endotherm/skin_and_insulation_temperature.jl
@@ -1,3 +1,34 @@
+function _insulation_evaporation(conv, atmos, area_convection, T_ins, air_temperature,
+                                  insulation_wetness, insulation_test; gas_fractions)
+    insulation_wetness > 0 && insulation_test > 0.0u"m" || return 0.0u"W"
+    evap_pars_ins = AnimalEvaporationParameters(;
+        skin_wetness = insulation_wetness,
+        eye_fraction = 0.0,
+        bare_skin_fraction = 1.0,
+    )
+    mass_ins = TransferCoefficients(conv.mass.combined, conv.mass.combined, conv.mass.forced)
+    evaporation(evap_pars_ins, mass_ins, atmos, area_convection, T_ins, air_temperature;
+                gas_fractions).evaporation_heat_flow
+end
+
+function _insulation_conductivity(insulation, insulation_pars, side, T_ins, T_skin, longwave_depth_fraction, σ)
+    insulation_temp_mean = T_ins * 0.7 + T_skin * 0.3
+    air_k = dry_air_properties(insulation_temp_mean).thermal_conductivity
+    side_depth = getproperty(insulation.fibres, side).depth
+    side_fibres = setproperties(getproperty(insulation_pars, side); depth = side_depth)
+    effective_conductivity = insulation_thermal_conductivity(side_fibres, air_k).effective_conductivity
+    absorption_coefficient = getproperty(insulation.absorption_coefficients, side)
+    approx_radiant_temperature = T_skin * (1 - longwave_depth_fraction) + T_ins * longwave_depth_fraction
+    radiative_conductivity = (16 * σ * approx_radiant_temperature^3) / (3 * absorption_coefficient)
+    return (; insulation_conductivity = effective_conductivity + radiative_conductivity, effective_conductivity)
+end
+
+function _radiation_coefficients(area, view_factors, ϵ, σ, T_rad, T_sky, T_bush, T_veg, T_gnd)
+    coeff(vf, T) = area * vf * 4 * ϵ * σ * ((T_rad + T) / 2)^3
+    RadiationCoeffs(coeff(view_factors.sky, T_sky), coeff(view_factors.bush, T_bush),
+                    coeff(view_factors.vegetation, T_veg), coeff(view_factors.ground, T_gnd))
+end
+
 """
     solve_temperatures(; body, insulation_pars, insulation, geometry_vars, environment_vars, traits, temperature_tolerance, skin_temperature, insulation_temperature)
 
@@ -131,15 +162,12 @@ function solve_without_insulation!(
             ).evaporation_heat_flow
 
             # Q_rad variables for radiant exchange
-            sky_radiation_coeff = area_convection * (view_factors.sky * 4.0 * ϵ_body * σ * ((skin_temperature + sky_temperature) / 2)^3)
-            bush_radiation_coeff =
-                area_convection * (view_factors.bush * 4.0 * ϵ_body * σ * ((skin_temperature + bush_temperature) / 2)^3)
-            vegetation_radiation_coeff =
-                area_convection *
-                (view_factors.vegetation * 4.0 * ϵ_body * σ * ((skin_temperature + vegetation_temperature) / 2)^3)
-            ground_radiation_coeff =
-                area_convection *
-                (view_factors.ground * 4.0 * ϵ_body * σ * ((skin_temperature + ground_temperature) / 2)^3)
+            _rc = _radiation_coefficients(area_convection, view_factors, ϵ_body, σ, skin_temperature,
+                sky_temperature, bush_temperature, vegetation_temperature, ground_temperature)
+            sky_radiation_coeff        = _rc.sky
+            bush_radiation_coeff       = _rc.bush
+            vegetation_radiation_coeff = _rc.vegetation
+            ground_radiation_coeff     = _rc.ground
             skin_temperature1 =
                 ((4.0 * flesh_conductivity * volume) / (r_skin^2) * core_temperature) - skin_evaporation_flow +
                 heat_transfer_coefficient * area_convection * air_temperature +
@@ -306,52 +334,22 @@ function solve_with_insulation!(
                 gas_fractions,
             ).evaporation_heat_flow
             # second from insulation
-            if insulation_wetness > 0 && insulation_test > 0.0u"m"
-                evap_pars_ins = AnimalEvaporationParameters(;
-                    skin_wetness=insulation_wetness,
-                    eye_fraction=0.0,
-                    bare_skin_fraction=1.0,
-                )
-                # Use combined for free (insulation uses combined mass transfer for all)
-                mass_ins = TransferCoefficients(conv.mass.combined, conv.mass.combined, conv.mass.forced)
-                insulation_evaporation_heat_flow = evaporation(
-                    evap_pars_ins,
-                    mass_ins,
-                    atmos_skin,
-                    area_convection,
-                    insulation_temperature,
-                    air_temperature;
-                    gas_fractions,
-                ).evaporation_heat_flow
-            else
-                insulation_evaporation_heat_flow = 0.0u"W"
-            end
+            insulation_evaporation_heat_flow = _insulation_evaporation(
+                conv, atmos_skin, area_convection, insulation_temperature, air_temperature,
+                insulation_wetness, insulation_test; gas_fractions)
             # Recompute insulation thermal properties for current temperatures
-            insulation_temp = insulation_temperature * 0.7 + skin_temperature * 0.3
-            air_k = dry_air_properties(insulation_temp).thermal_conductivity
-            side_depth = getproperty(insulation.fibres, side).depth
-            side_fibres = setproperties(getproperty(insulation_pars, side); depth=side_depth)
-            side_thermal = insulation_thermal_conductivity(side_fibres, air_k)
-
-            # Update conductivities for the current side
+            (; insulation_conductivity, effective_conductivity) = _insulation_conductivity(
+                insulation, insulation_pars, side, insulation_temperature, skin_temperature,
+                longwave_depth_fraction, σ)
             side_conductivities = if side == :dorsal
-                setproperties(insulation.conductivities; dorsal=side_thermal.effective_conductivity)
+                setproperties(insulation.conductivities; dorsal=effective_conductivity)
             else
-                setproperties(insulation.conductivities; ventral=side_thermal.effective_conductivity)
+                setproperties(insulation.conductivities; ventral=effective_conductivity)
             end
-            absorption_coefficient = getproperty(insulation.absorption_coefficients, side)
-            effective_conductivity = getproperty(side_conductivities, side)
-            # update thermally sensitive insulation parameters for current skin/insulation temperature
             insulation = setproperties(insulation;
-                conductivity_compressed=side_thermal.effective_conductivity,
+                conductivity_compressed=effective_conductivity,
                 conductivities=side_conductivities,
             )
-            # Effective insulation conductivity
-            approx_radiant_temperature =
-                skin_temperature * (1 - longwave_depth_fraction) +
-                insulation_temperature * longwave_depth_fraction
-            radiative_conductivity = (16 * σ * approx_radiant_temperature^3) / (3 * absorption_coefficient)
-            insulation_conductivity = effective_conductivity + radiative_conductivity
             conductivities = ThermalConductivities(flesh_conductivity, fat_conductivity, insulation_conductivity)
             org_temps = OrganismTemperatures(core_temperature, skin_temperature, insulation_temperature)
             radiant_temp_result = radiant_temperature(;
@@ -372,19 +370,13 @@ function solve_with_insulation!(
             conductances = radiant_temp_result.conductances
             divisors = radiant_temp_result.divisors
             # Radiative heat flows
-            sky_radiation_coeff = area_convection * view_factors.sky * 4 * ϵ_body * σ * ((calculated_radiant_temperature + sky_temperature) / 2)^3
-            bush_radiation_coeff =
-                area_convection * view_factors.bush * 4 * ϵ_body * σ * ((calculated_radiant_temperature + bush_temperature) / 2)^3
-            vegetation_radiation_coeff =
-                area_convection *
-                view_factors.vegetation *
-                4 *
-                ϵ_body *
-                σ *
-                ((calculated_radiant_temperature + vegetation_temperature) / 2)^3
-            ground_radiation_coeff =
-                area_convection * view_factors.ground * 4 * ϵ_body * σ * ((calculated_radiant_temperature + ground_temperature) / 2)^3
-            radiation_coeffs = RadiationCoeffs(sky_radiation_coeff, bush_radiation_coeff, vegetation_radiation_coeff, ground_radiation_coeff)
+            radiation_coeffs = _radiation_coefficients(area_convection, view_factors, ϵ_body, σ,
+                calculated_radiant_temperature,
+                sky_temperature, bush_temperature, vegetation_temperature, ground_temperature)
+            sky_radiation_coeff        = radiation_coeffs.sky
+            bush_radiation_coeff       = radiation_coeffs.bush
+            vegetation_radiation_coeff = radiation_coeffs.vegetation
+            ground_radiation_coeff     = radiation_coeffs.ground
             env_temps = EnvironmentTemperatures(
                 air_temperature, sky_temperature, ground_temperature, vegetation_temperature, bush_temperature, substrate_temperature
             )

--- a/src/endotherm/skin_and_insulation_temperature.jl
+++ b/src/endotherm/skin_and_insulation_temperature.jl
@@ -114,7 +114,7 @@ function solve_without_insulation!(
                 convection_enhancement,
             )
             heat_transfer_coefficient = conv.heat.combined
-            evap_pars_local = EvaporationParameters(;
+            evap_pars_local = AnimalEvaporationParameters(;
                 skin_wetness,
                 eye_fraction,
                 bare_skin_fraction,
@@ -290,7 +290,7 @@ function solve_with_insulation!(
                 convection_enhancement,
             )
             heat_transfer_coefficient = conv.heat.combined
-            evap_pars_skin = EvaporationParameters(;
+            evap_pars_skin = AnimalEvaporationParameters(;
                 skin_wetness,
                 eye_fraction,
                 bare_skin_fraction,
@@ -307,7 +307,7 @@ function solve_with_insulation!(
             ).evaporation_heat_flow
             # second from insulation
             if insulation_wetness > 0 && insulation_test > 0.0u"m"
-                evap_pars_ins = EvaporationParameters(;
+                evap_pars_ins = AnimalEvaporationParameters(;
                     skin_wetness=insulation_wetness,
                     eye_fraction=0.0,
                     bare_skin_fraction=1.0,

--- a/src/endotherm/types.jl
+++ b/src/endotherm/types.jl
@@ -55,19 +55,19 @@ struct RadiationCoeffs{T1,T2,T3,T4}
 end
 
 """
-    BodyRegionValues{T}
+    BodyRegionValues{A,D,V}
 
 Container for average, dorsal, and ventral surface values.
 
 # Fields
-- `average::T` — Weighted average value across body surface
-- `dorsal::T` — Dorsal (upper/back) surface value
-- `ventral::T` — Ventral (lower/belly) surface value
+- `average::A` — Weighted average value across body surface
+- `dorsal::D` — Dorsal (upper/back) surface value
+- `ventral::V` — Ventral (lower/belly) surface value
 """
-struct BodyRegionValues{T}
-    average::T
-    dorsal::T
-    ventral::T
+struct BodyRegionValues{A,D,V}
+    average::A
+    dorsal::D
+    ventral::V
 end
 
 """

--- a/src/insulation.jl
+++ b/src/insulation.jl
@@ -115,7 +115,7 @@ Compute parameters for heat conduction and longwave radiation through insulation
 - `conductivity_compressed`: Conductivity of compressed ventral insulation (W/m/K).
 """
 function insulation_properties(insulation::InsulationParameters, insulation_temperature, ventral_fraction)
-    (; dorsal, ventral, depth_compressed) = insulation
+    (; dorsal, ventral, depth_compressed) = stripparams(insulation)
 
     # Physical constants
     air_conductivity = dry_air_properties(insulation_temperature).thermal_conductivity

--- a/src/leaf/leaf.jl
+++ b/src/leaf/leaf.jl
@@ -1,0 +1,94 @@
+# Leaf heat balance dispatch
+
+"""
+    heat_balance(leaf_temperature, evap_pars::LeafEvaporationParameters, organism::Organism, e)
+
+Calculate heat balance for a leaf at a given leaf temperature.
+
+The leaf is treated as a thin, isothermal surface: a high `flesh_conductivity` in the
+`InternalConductionParameters` will make surface ≈ internal temperature. For thick succulent
+stems (cactus), set flesh_conductivity to the appropriate tissue value.
+
+Transpiration is computed from stomatal vapour conductances via
+`evaporation(::LeafEvaporationParameters, ...)`.
+
+# Arguments
+- `leaf_temperature`: Leaf temperature to evaluate (K)
+- `evap_pars::LeafEvaporationParameters`: Stomatal and cuticular conductances
+- `organism::Organism`: Organism with body geometry and traits
+- `e`: Environment containing `environment_pars` and `environment_vars`
+
+# Returns
+NamedTuple with:
+- `heat_balance`: Net heat balance (W; zero at steady-state)
+- `leaf_temperature`: Input leaf temperature (K)
+- `surface_temperature`: Leaf surface temperature (K)
+- `energy_balance`: NamedTuple of heat flow components
+- `mass_balance`: NamedTuple with `transpiration_mass` (g/s) and `oxygen_consumption_rate` (ml/hr)
+- `evaporation_out`: Full evaporation output
+- `solar_out`, `longwave_gain_out`, `longwave_loss_out`, `convection_out`: Detailed outputs
+"""
+function heat_balance(leaf_temperature, evap_pars::LeafEvaporationParameters, o::Organism, e)
+    environment_pars = stripparams(e.environment_pars)
+    environment_vars = e.environment_vars
+    internal_conduction = conduction_pars_internal(o)
+    hyd_pars = hydraulic_pars(o)
+    metab_pars = metabolism_pars(o)
+
+    # metabolism (dark respiration or nothing)
+    metabolic_heat_flow = metabolic_rate(metab_pars.model, o.body.shape.mass, leaf_temperature)
+
+    # net specific metabolic heat → surface temperature
+    specific_metabolic_heat_production = metabolic_heat_flow / o.body.geometry.volume
+    (; surface_temperature) = surface_and_lung_temperature(;
+        body=o.body,
+        flesh_conductivity=internal_conduction.flesh_conductivity,
+        specific_metabolic_heat_production,
+        core_temperature=leaf_temperature,
+    )
+
+    # radiative + convective flows
+    flows = _radiative_convective_flows(surface_temperature, o, environment_pars, environment_vars)
+    (; solar_flow, longwave_flow_in, longwave_flow_out,
+       convection_heat_flow, convection_out, convection_area,
+       solar_out, longwave_gain_out, longwave_loss_out) = flows
+
+    # transpiration
+    atmos = AtmosphericConditions(environment_vars)
+    evaporation_out = evaporation(
+        evap_pars,
+        convection_out.mass,
+        atmos,
+        convection_area,
+        surface_temperature,
+        environment_vars.air_temperature;
+        water_potential=hyd_pars.water_potential,
+        gas_fractions=environment_pars.gas_fractions,
+    )
+    evaporation_heat_flow = evaporation_out.evaporation_heat_flow
+
+    # heat balance (no respiration term for leaves — included in metabolic_heat_flow if needed)
+    heat_balance_val = solar_flow + longwave_flow_in + metabolic_heat_flow -
+                       longwave_flow_out - convection_heat_flow - evaporation_heat_flow
+
+    energy_balance = (;
+        solar_flow, longwave_flow_in, longwave_flow_out,
+        convection_heat_flow, evaporation_heat_flow,
+        metabolic_heat_flow, heat_balance=heat_balance_val,
+    )
+    oxygen_consumption_rate = u"ml/hr"(Joules_to_O2(Kleiber1961(), metabolic_heat_flow, 1.0))
+    mass_balance = (; transpiration_mass=evaporation_out.transpiration_water_loss, oxygen_consumption_rate)
+
+    return (;
+        heat_balance=heat_balance_val,
+        leaf_temperature,
+        surface_temperature,
+        energy_balance,
+        mass_balance,
+        evaporation_out,
+        solar_out,
+        longwave_gain_out,
+        longwave_loss_out,
+        convection_out,
+    )
+end

--- a/src/metabolism.jl
+++ b/src/metabolism.jl
@@ -84,6 +84,44 @@ function metabolic_rate(::McKechnieWolf, mass, core_temperature=nothing)
 end
 
 """
+    PlantDarkRespiration <: MetabolicRateEquation
+
+Leaf/plant dark (mitochondrial) respiration using mass scaling and Arrhenius
+temperature dependence (Reich et al. 2006; CLM/LPJ parameterisation).
+
+    R = mass_normalisation × mass^mass_exponent
+        × exp(-activation_energy / (k × T))
+        / exp(-activation_energy / (k × reference_temperature))
+
+# Parameters
+- `mass_normalisation` — respiration rate per unit mass at reference temperature (W/kg)
+- `mass_exponent` — allometric exponent; default 1.0 (near-isometric for plants; Reich 2006)
+- `activation_energy` — Arrhenius activation energy (eV); default 0.65 eV
+- `reference_temperature` — normalisation temperature (K); default 298.15 K (25 °C)
+
+# References
+- Reich, P. B., et al. (2006). Universal scaling of respiratory metabolism, size and nitrogen in plants.
+  *Nature*, 439, 457–461.
+"""
+@kwdef struct PlantDarkRespiration <: MetabolicRateEquation
+    mass_normalisation::Float64    = 4.6e-4    # W/kg at 25 °C; broad C3 leaf estimate
+    mass_exponent::Float64         = 1.0
+    activation_energy::Float64     = 0.65      # eV
+    reference_temperature::Float64 = 298.15    # K
+end
+
+function metabolic_rate(eq::PlantDarkRespiration, mass, temperature)
+    (; mass_normalisation, mass_exponent, activation_energy, reference_temperature) = eq
+    k_eV = 8.617333e-5   # Boltzmann constant, eV/K
+    T    = ustrip(u"K", temperature)
+    M    = ustrip(u"kg", mass)
+    rate = mass_normalisation * M^mass_exponent *
+           exp(-activation_energy / (k_eV * T)) /
+           exp(-activation_energy / (k_eV * reference_temperature))
+    return rate * u"W"
+end
+
+"""
     metabolic_rate(::Nothing, mass, T_body)
 
 Returns zero metabolic heat production. Use `model = nothing` in
@@ -170,8 +208,7 @@ function Joules_to_O2(::Kleiber1961, metabolic_heat_flow, rq)
     protein_energy_equivalent = u"J/ml"(4.5u"kcal"/1u"L")
     if rq ≥ 1.0
         oxygen_flow_standard = metabolic_heat_flow / carbohydrate_energy_equivalent
-    end
-    if rq ≤ 0.7
+    elseif rq ≤ 0.7
         oxygen_flow_standard = metabolic_heat_flow / fat_energy_equivalent
     else
         oxygen_flow_standard = metabolic_heat_flow / protein_energy_equivalent
@@ -185,8 +222,7 @@ function O2_to_Joules(::Kleiber1961, oxygen_flow_standard, rq)
     protein_energy_equivalent = u"J/ml"(4.5u"kcal"/1u"L")
     if rq ≥ 1.0
         metabolic_heat_flow = oxygen_flow_standard * carbohydrate_energy_equivalent
-    end
-    if rq ≤ 0.7
+    elseif rq ≤ 0.7
         metabolic_heat_flow = oxygen_flow_standard * fat_energy_equivalent
     else
         metabolic_heat_flow = oxygen_flow_standard * protein_energy_equivalent

--- a/src/respiration.jl
+++ b/src/respiration.jl
@@ -31,8 +31,8 @@ function respiration(
 )
     (; metabolic, sum, minimum) = rates
     metabolic_heat_flow, heat_flow_sum, minimum_heat_flow = metabolic, sum, minimum
-    (; oxygen_extraction_efficiency, pant, respiratory_quotient, exhaled_temperature_offset, exhaled_relative_humidity) = resp_pars
-    exit_air_temperature = lung_temperature  # exhaled air at lung temperature (original default)
+    (; oxygen_extraction_efficiency, pant, respiratory_quotient, exhaled_relative_humidity) = resp_pars
+    exit_air_temperature = lung_temperature
     (; relative_humidity, atmospheric_pressure) = atmos
     fO2 = gas_fractions.oxygen
     fCO2 = gas_fractions.carbon_dioxide
@@ -49,8 +49,8 @@ function respiration(
 
     # converting standard temperature and pressure -> vol. of O2 at animal lung temperature, atm. press.
     O2_partial_pressure = atmospheric_pressure * fO2
-    oxygen_flow = oxygen_flow_standard * (lung_temperature / 273.15u"K") * (101325u"Pa" / atmospheric_pressure)
-    #n = PV/RT (ideal gas law: number of moles from press,vol,temp)
+    O2_ref = 101325u"Pa" * fO2
+    oxygen_flow = oxygen_flow_standard * (O2_ref / 273.15u"K") * (lung_temperature / O2_partial_pressure)    #n = PV/RT (ideal gas law: number of moles from press,vol,temp)
     oxygen_consumed = uconvert(u"mol/s", atmospheric_pressure * oxygen_flow / (Unitful.R * lung_temperature)) # mol O2 consumed
     # moles/s of O2, N2, dry air at entrance [air flow = f(O2 consumption)]
     oxygen_in = oxygen_consumed / oxygen_extraction_efficiency # actual oxygen flow in (moles/s), accounting for efficiency of extraction
@@ -72,8 +72,7 @@ function respiration(
     # total moles of air at exit will be approximately the same as at entrance, since
     # the moles of O2 removed = approx. the # moles of co2 added
     air_out = (oxygen_out + nitrogen_out + carbon_dioxide_out) * pant
-    # assuming saturated air at exit
-    exit_vapour_pressure = vapour_pressure(exit_air_temperature)
+    exit_vapour_pressure = vapour_pressure(exit_air_temperature) * exhaled_relative_humidity
     water_out = air_out * (exit_vapour_pressure / (atmospheric_pressure - exit_vapour_pressure))
     # enthalpy = U2-U1, internal energy only, i.e. lat. heat of vap. only involved, since assume
     # P,T,V constant, so not significant flow energy, PV. (H = U + PV)

--- a/src/respiration.jl
+++ b/src/respiration.jl
@@ -38,7 +38,7 @@ function respiration(
     fCO2 = gas_fractions.carbon_dioxide
     fN2 = gas_fractions.nitrogen
     # adjust O2 to ensure sum to 1
-    if fO2 + fCO2 + fN2 != 1
+    if !isapprox(fO2 + fCO2 + fN2, 1; atol=1e-6)
         fO2 = 1 - (fN2 + fCO2)
     end
 
@@ -49,21 +49,22 @@ function respiration(
 
     # converting standard temperature and pressure -> vol. of O2 at animal lung temperature, atm. press.
     O2_partial_pressure = atmospheric_pressure * fO2
-    oxygen_flow = (oxygen_flow_standard * O2_partial_pressure / 273.15u"K") * (lung_temperature / O2_partial_pressure)
+    oxygen_flow = oxygen_flow_standard * (lung_temperature / 273.15u"K") * (101325u"Pa" / atmospheric_pressure)
     #n = PV/RT (ideal gas law: number of moles from press,vol,temp)
     oxygen_consumed = uconvert(u"mol/s", atmospheric_pressure * oxygen_flow / (Unitful.R * lung_temperature)) # mol O2 consumed
     # moles/s of O2, N2, dry air at entrance [air flow = f(O2 consumption)]
     oxygen_in = oxygen_consumed / oxygen_extraction_efficiency # actual oxygen flow in (moles/s), accounting for efficiency of extraction
     nitrogen_in = oxygen_in * (fN2 / fO2) #  actual nitrogen flow in (moles/s), accounting for efficiency of extraction
-    air_flow = oxygen_flow / fO2 # air flow
-    co2_flow = fCO2 * air_flow # CO2 flow
+    air_flow_raw = oxygen_flow / fO2 # air flow
+    co2_flow = fCO2 * air_flow_raw # CO2 flow
     carbon_dioxide_in = atmospheric_pressure * co2_flow / (Unitful.R * lung_temperature)
     air_in = (oxygen_in + nitrogen_in + carbon_dioxide_in) * pant
     air_flow = uconvert(u"m^3/s", (air_in * Unitful.R * 273.15u"K" / 101325u"Pa")) # air volume at standard temperature and pressure (m3/s)
     # computing the vapor pressure at saturation for the subsequent calculation of
     # actual moles of water based on actual relative humidity
     saturation_vapour_pressure = vapour_pressure(air_temperature)
-    water_in = air_in * (saturation_vapour_pressure * relative_humidity) / (atmospheric_pressure - saturation_vapour_pressure * relative_humidity)
+    water_in = air_in * (saturation_vapour_pressure * relative_humidity) / 
+        max(atmospheric_pressure - saturation_vapour_pressure * relative_humidity, 1e-6u"Pa")
     # moles at exit
     oxygen_out = oxygen_in - oxygen_consumed # remove consumed oxygen from the total
     nitrogen_out = nitrogen_in
@@ -95,11 +96,6 @@ function respiration(
     # (edwards & haines 1978. j. comp. physiol. 128: 177-184 in welch 1980)
     # for a 0.01 kg animal, the max. rate would be 1.67 x 10^-6 g/s
     respiration_mass = min(respiration_mass, (2.22E-03 * ustrip(u"kg", mass) * 15)u"g/s")
-
-    # get latent heat of vapourisation and compute heat exchange due to respiration
-    latent_heat_vaporisation = enthalpy_of_vaporisation(lung_temperature)
-    # heat loss by breathing (J/s)=(J/kg)*(kg/s)
-    respiration_heat_flow = uconvert(u"W", latent_heat_vaporisation * respiration_mass)
 
     # get latent heat of vapourisation and compute heat exchange due to respiration
     latent_heat_vaporisation = enthalpy_of_vaporisation(lung_temperature)

--- a/src/respiration.jl
+++ b/src/respiration.jl
@@ -33,6 +33,7 @@ function respiration(
     metabolic_heat_flow, heat_flow_sum, minimum_heat_flow = metabolic, sum, minimum
     (; oxygen_extraction_efficiency, pant, respiratory_quotient, exhaled_relative_humidity) = resp_pars
     exit_air_temperature = lung_temperature
+    exhaled_rh = exhaled_relative_humidity[]
     (; relative_humidity, atmospheric_pressure) = atmos
     fO2 = gas_fractions.oxygen
     fCO2 = gas_fractions.carbon_dioxide
@@ -72,7 +73,7 @@ function respiration(
     # total moles of air at exit will be approximately the same as at entrance, since
     # the moles of O2 removed = approx. the # moles of co2 added
     air_out = (oxygen_out + nitrogen_out + carbon_dioxide_out) * pant
-    exit_vapour_pressure = vapour_pressure(exit_air_temperature) * exhaled_relative_humidity
+    exit_vapour_pressure = vapour_pressure(exit_air_temperature) * exhaled_rh
     water_out = air_out * (exit_vapour_pressure / (atmospheric_pressure - exit_vapour_pressure))
     # enthalpy = U2-U1, internal energy only, i.e. lat. heat of vap. only involved, since assume
     # P,T,V constant, so not significant flow energy, PV. (H = U + PV)

--- a/src/rootfinding.jl
+++ b/src/rootfinding.jl
@@ -75,7 +75,7 @@ function zbrent(f, a::Real, b::Real, tol::Real; maxiter::Int=300, eps::Float64=3
         xm   = (c - b) / 2
 
         (abs(xm) ≤ tol1 || qb == 0) && return b
-        abs(qb) ≤ tol1 && i > 1     && return b
+        abs(qb) ≤ tol && i > 1     && return b
 
         if abs(e) ≥ tol1 && abs(qa) > abs(qb)
             s = qb / qa

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,4 +1,50 @@
 
+# Characteristic dimension formulas
+
+"""
+    CharacteristicDimFormula
+
+Abstract supertype for characteristic dimension formulas used in convection calculations.
+"""
+abstract type CharacteristicDimFormula end
+
+"""
+    VolumeCubeRoot <: CharacteristicDimFormula
+
+Use `V^(1/3) + insulation_thickness` as the characteristic dimension (default).
+Insulation thickness is added for furred animals to reflect the outer scale.
+"""
+struct VolumeCubeRoot <: CharacteristicDimFormula end
+
+"""
+    ScaledDimension(factor, dimension::Symbol)
+
+Characteristic dimension = `factor × body.geometry.length.<dimension>`.
+
+`dimension` names a field in the shape's `length` NamedTuple —
+e.g. `:width_skin`, `:b_semi_minor_skin`, `:radius_skin`. Use this when
+the volume-cube-root scale is inappropriate, such as flat plates or oblate ellipsoids.
+The factor defaults to 1.0.
+"""
+struct ScaledDimension{F} <: CharacteristicDimFormula
+    factor::F
+    dimension::Symbol
+end
+ScaledDimension(dimension::Symbol) = ScaledDimension(1.0, dimension)
+
+_outer_insulation_thickness(::Naked)   = 0.0u"m"
+_outer_insulation_thickness(::Fat)     = 0.0u"m"
+_outer_insulation_thickness(f::Fur)    = f.thickness
+function _outer_insulation_thickness(ci::CompositeInsulation)
+    _outer_insulation_thickness(BiophysicalGeometry.outer_insulation(ci))
+end
+
+characteristic_dimension(::VolumeCubeRoot, body) =
+    body.geometry.volume^(1/3) + _outer_insulation_thickness(body.insulation)
+
+characteristic_dimension(sd::ScaledDimension, body) =
+    sd.factor * getproperty(body.geometry.length, sd.dimension)
+
 """
     ExternalConductionParameters <: AbstractMorphologyParameters
 
@@ -38,10 +84,12 @@ Morphological parameters relating to convective heat exchange.
 
 # Parameters
 - `convection_area` — surface area involved in convection.
-
+- `characteristic_dimension_formula` — formula used to compute the characteristic dimension
+  for convection scaling (default: `VolumeCubeRoot()`).
 """
-Base.@kwdef struct ConvectionParameters{A} <: AbstractMorphologyParameters
+Base.@kwdef struct ConvectionParameters{A,CDF} <: AbstractMorphologyParameters
     convection_area::A = Param(0.0u"m^2")
+    characteristic_dimension_formula::CDF = VolumeCubeRoot()
 end
 
 """

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -103,6 +103,26 @@ Base.@kwdef struct EvaporationParameters{SW,IW,EF,BF,IF} <: AbstractMorphologyPa
 end
 
 """
+    LeafEvaporationParameters <: AbstractMorphologyParameters
+
+Evaporation parameters for a leaf using stomatal vapour conductances (mol/m²/s).
+The boundary layer conductance is supplied via `mass::TransferCoefficients` from
+a prior `convection()` call, ensuring the same body geometry and convective
+enhancement factor are used for both heat and mass transfer.
+
+# Parameters
+- `abaxial_vapour_conductance` — Stomatal conductance of the abaxial (lower) surface (mol/m²/s); default 0.3.
+- `adaxial_vapour_conductance` — Stomatal conductance of the adaxial (upper) surface (mol/m²/s); default 0.0.
+- `cuticular_conductance` — Baseline conductance when stomata are closed (mol/m²/s); added equally
+  to both surfaces (`cuticular_conductance / 2` per side). Equivalent to ~0.1 µmol H₂O/(m²·s·Pa); default 0.01.
+"""
+Base.@kwdef struct LeafEvaporationParameters{AB,AD,CC} <: AbstractMorphologyParameters
+    abaxial_vapour_conductance::AB = Param(0.3u"mol/m^2/s",  bounds=(0.0, Inf))
+    adaxial_vapour_conductance::AD = Param(0.0u"mol/m^2/s",  bounds=(0.0, Inf))
+    cuticular_conductance::CC      = Param(0.01u"mol/m^2/s", bounds=(0.0, Inf))
+end
+
+"""
     HydraulicParameters <: AbstractPhysiologyParameters
 
 Morphological parameters relating to radiation exchange.

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -82,7 +82,7 @@ Base.@kwdef struct RadiationParameters{AD,AV,ED,EV,AS,AT,AC,FS,FG,FV,FB,VF} <:
 end
 
 """
-    EvaporationParameters <: AbstractMorphologyParameters
+    AnimalEvaporationParameters <: AbstractMorphologyParameters
 
 Morphological parameters relating to cutaneous evaporation of the organism.
 
@@ -94,7 +94,7 @@ Morphological parameters relating to cutaneous evaporation of the organism.
 - `insulation_fraction::F` — Fraction of surface area covered by insulation (0–1).
 
 """
-Base.@kwdef struct EvaporationParameters{SW,IW,EF,BF,IF} <: AbstractMorphologyParameters
+Base.@kwdef struct AnimalEvaporationParameters{SW,IW,EF,BF,IF} <: AbstractMorphologyParameters
     skin_wetness::SW = Param(0.0, bounds=(0.0, 1.0))
     insulation_wetness::IW = Param(1, bounds=(0.0, 1.0))
     eye_fraction::EF = Param(0.0, bounds=(0.0, 1.0))

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -1,0 +1,48 @@
+using HeatExchange
+using Test
+using Unitful
+using UnitfulMoles
+
+@testset "leaf evaporation" begin
+    # Representative mass transfer coefficients (m/s) for a leaf-sized body.
+    # These are supplied from convection() in practice; we construct them directly here
+    # to keep the test independent of the pre-existing convection() gas_fractions keyword bug.
+    mass_windy = TransferCoefficients(0.005u"m/s", 0.001u"m/s", 0.004u"m/s")
+    mass_calm  = TransferCoefficients(0.001u"m/s", 0.001u"m/s", 0.0u"m/s")
+
+    air_temperature      = u"K"(30.0u"°C")
+    surface_temperature  = u"K"(35.0u"°C")
+    area                 = 0.01u"m^2"
+    atmos = AtmosphericConditions(0.2, 2.0u"m/s", 101325.0u"Pa")
+
+    leaf_pars = LeafEvaporationParameters(;
+        abaxial_vapour_conductance = 0.3u"mol/m^2/s",
+        adaxial_vapour_conductance = 0.0u"mol/m^2/s",
+        cuticular_conductance      = 0.01u"mol/m^2/s",
+    )
+
+    out = evaporation(leaf_pars, mass_windy, atmos, area, surface_temperature, air_temperature)
+
+    # Positive heat loss when leaf is warmer and drier than air
+    @test out.evaporation_heat_flow > 0.0u"W"
+    @test out.transpiration_water_loss > 0.0u"g/s"
+
+    # Stomata fully closed → much less transpiration than open stomata
+    leaf_pars_closed = LeafEvaporationParameters(;
+        abaxial_vapour_conductance = 0.0u"mol/m^2/s",
+        adaxial_vapour_conductance = 0.0u"mol/m^2/s",
+        cuticular_conductance      = 0.01u"mol/m^2/s",
+    )
+    out_closed = evaporation(leaf_pars_closed, mass_windy, atmos, area, surface_temperature, air_temperature)
+    @test out_closed.transpiration_water_loss < out.transpiration_water_loss
+    @test out_closed.evaporation_heat_flow > 0.0u"W"
+
+    # Less boundary layer transport (calmer conditions) → less evaporation
+    out_calm = evaporation(leaf_pars, mass_calm, atmos, area, surface_temperature, air_temperature)
+    @test out_calm.evaporation_heat_flow < out.evaporation_heat_flow
+
+    # Negative water potential reduces surface humidity → less evaporation
+    out_dry = evaporation(leaf_pars, mass_windy, atmos, area, surface_temperature, air_temperature;
+        water_potential = -1e6u"J/kg")
+    @test out_dry.evaporation_heat_flow < out.evaporation_heat_flow
+end

--- a/test/ectotherm.jl
+++ b/test/ectotherm.jl
@@ -225,7 +225,7 @@ A_eff = A_convection * skin_wetness
 @test A_sil_normal ≈ (ecto_output.ASILN)u"m^2" rtol=1e-9
 @test A_sil_parallel ≈ (ecto_output.ASILP)u"m^2" rtol=1e-9
 @test A_eff ≈ (ecto_output.AEFF)u"m^2" rtol=1e-9
-@test geometry.geometry.characteristic_dimension ≈ (ecto_output.AL)u"m" rtol=1e-9
+@test characteristic_dimension(HeatExchange.VolumeCubeRoot(), geometry) ≈ (ecto_output.AL)u"m" rtol=1e-9
 @test geometry.geometry.length[1] ≈ (ecto_output.R1)u"m" rtol=1e-9
 @test geometry.geometry.volume ≈ (ecto_output.VOL)u"m^3" rtol=1e-9
 

--- a/test/ectotherm.jl
+++ b/test/ectotherm.jl
@@ -170,8 +170,8 @@ convection_enhancement = ecto_input.conv_enhance
 # organism morphology
 mass = u"kg"((ecto_input.Ww_g)u"g")
 ρ_flesh = (ecto_input.rho_body)u"kg/m^3"
-shape_b = ecto_input.shape_b
-shape_c = ecto_input.shape_c
+aspect_ratio_b = ecto_input.shape_b
+aspect_ratio_c = ecto_input.shape_c
 eye_fraction = ecto_input.pct_eyes / 100
 conduction_fraction = ecto_input.pct_cond / 100
 
@@ -209,7 +209,7 @@ pant = 1.0
 
 # geometry
 shape_pars = DesertIguana(mass, ρ_flesh)
-#shape_pars = Cylinder(mass, ρ_flesh, shape_b)
+#shape_pars = Cylinder(mass, ρ_flesh, aspect_ratio_b)
 geometry = Body(shape_pars, Naked())
 A_total = total_area(geometry)
 A_sil_normal = silhouette_area(shape_pars, NormalToSun())

--- a/test/ectotherm.jl
+++ b/test/ectotherm.jl
@@ -325,7 +325,7 @@ conv_out = convection(;
 convection_heat_flow = conv_out.heat_flow
 
 # evaporation
-evap_pars_test = EvaporationParameters(; skin_wetness, eye_fraction, bare_skin_fraction=1.0)
+evap_pars_test = AnimalEvaporationParameters(; skin_wetness, eye_fraction, bare_skin_fraction=1.0)
 atmos_test = AtmosphericConditions(relative_humidity, wind_speed, atmospheric_pressure)
 evap_out = evaporation(evap_pars_test, conv_out.mass, atmos_test, A_convection, skin_temperature, air_temperature; water_potential=ψ_org, gas_fractions)
 evaporation_heat_flow = evap_out.evaporation_heat_flow
@@ -369,7 +369,7 @@ radiation_pars = RadiationParameters(;
 
 convection_pars = ConvectionParameters(; convection_area=A_convection)
 
-evaporation_pars = EvaporationParameters(; skin_wetness, eye_fraction)
+evaporation_pars = AnimalEvaporationParameters(; skin_wetness, eye_fraction)
 
 hydraulic_pars = HydraulicParameters(; water_potential=ψ_org)
 
@@ -413,36 +413,36 @@ environment_vars = EnvironmentalVars(;
 )
 
 environment = (; environment_pars, environment_vars)
-# define the method 'ectotherm' for passing to find_zero, which dispatches off 'lizard'
+# define the method 'heat_balance' for passing to find_zero, which dispatches off 'lizard'
 air_temperature = environment_vars.air_temperature
-ectotherm(air_temperature, lizard, environment)
+heat_balance(air_temperature, lizard, environment)
 
 core_temperature_s = find_zero(
-    t -> ectotherm(t, lizard, environment), (air_temperature - 40u"K", air_temperature + 100u"K"), Bisection()
+    t -> heat_balance(t, lizard, environment), (air_temperature - 40u"K", air_temperature + 100u"K"), Bisection()
 )
 core_temperature_C = (Unitful.ustrip(core_temperature_s) - 273.15)u"°C"
 
 # test core temperature calculation
 @test core_temperature_C ≈ (ecto_output.TC)u"°C" rtol=1e-4
 
-heat_balance_out = ectotherm(core_temperature_s, lizard, environment)
+heat_balance_out = heat_balance(core_temperature_s, lizard, environment)
 
 @test heat_balance_out.core_temperature ≈ (ecto_output.TC + 273.15)u"K" rtol=1e-5
 @test heat_balance_out.surface_temperature ≈ (ecto_output.TSKIN + 273.15)u"K" rtol=1e-5
 @test heat_balance_out.lung_temperature ≈ (ecto_output.TLUNG + 273.15)u"K" rtol=1e-5
 
-@test heat_balance_out.enbal.solar_flow ≈ (ecto_output.QSOL)u"W" rtol=1e-9
-@test heat_balance_out.enbal.longwave_flow_in ≈ (ecto_output.QIRIN)u"W" rtol=1e-3 # TODO make better?
-@test heat_balance_out.enbal.longwave_flow_out ≈ (ecto_output.QIROUT)u"W" rtol=1e-3 # TODO make better?
-@test heat_balance_out.enbal.conduction_flow ≈ (ecto_output.QCOND)u"W" rtol=1e-3 # TODO make better?
-@test heat_balance_out.enbal.convection_heat_flow ≈ (ecto_output.QCONV)u"W" rtol=1e-4
-@test heat_balance_out.enbal.evaporation_heat_flow ≈ (ecto_output.QEVAP)u"W" rtol=1e-4
-@test heat_balance_out.enbal.metabolic_heat_flow ≈ (ecto_output.QMET)u"W" rtol=1e-4 # TODO make better?
-@test heat_balance_out.enbal.respiration_heat_flow ≈ (ecto_output.QRESP)u"W" rtol=1e-3 # TODO make better?
+@test heat_balance_out.energy_balance.solar_flow ≈ (ecto_output.QSOL)u"W" rtol=1e-9
+@test heat_balance_out.energy_balance.longwave_flow_in ≈ (ecto_output.QIRIN)u"W" rtol=1e-3 # TODO make better?
+@test heat_balance_out.energy_balance.longwave_flow_out ≈ (ecto_output.QIROUT)u"W" rtol=1e-3 # TODO make better?
+@test heat_balance_out.energy_balance.conduction_flow ≈ (ecto_output.QCOND)u"W" rtol=1e-3 # TODO make better?
+@test heat_balance_out.energy_balance.convection_heat_flow ≈ (ecto_output.QCONV)u"W" rtol=1e-4
+@test heat_balance_out.energy_balance.evaporation_heat_flow ≈ (ecto_output.QEVAP)u"W" rtol=1e-4
+@test heat_balance_out.energy_balance.metabolic_heat_flow ≈ (ecto_output.QMET)u"W" rtol=1e-4 # TODO make better?
+@test heat_balance_out.energy_balance.respiration_heat_flow ≈ (ecto_output.QRESP)u"W" rtol=1e-3 # TODO make better?
 
-@test heat_balance_out.masbal.oxygen_flow ≈ (ecto_output.O2_ml)u"ml/hr" rtol=1e-4 # TODO make better?
-@test heat_balance_out.masbal.cutaneous_mass ≈ (ecto_output.H2OCut_g / 3600)u"g/s" rtol=1e-4 # TODO make better?
-@test heat_balance_out.masbal.eye_mass ≈ (ecto_output.H2OEyes_g / 3600)u"g/s" rtol=1e-4 # TODO make better?
+@test heat_balance_out.mass_balance.oxygen_flow ≈ (ecto_output.O2_ml)u"ml/hr" rtol=1e-4 # TODO make better?
+@test heat_balance_out.mass_balance.cutaneous_mass ≈ (ecto_output.H2OCut_g / 3600)u"g/s" rtol=1e-4 # TODO make better?
+@test heat_balance_out.mass_balance.eye_mass ≈ (ecto_output.H2OEyes_g / 3600)u"g/s" rtol=1e-4 # TODO make better?
 
 molar_fluxes_in = heat_balance_out.respiration_out.molar_fluxes_in
 molar_fluxes_out = heat_balance_out.respiration_out.molar_fluxes_out

--- a/test/endotherm.jl
+++ b/test/endotherm.jl
@@ -187,7 +187,7 @@ for shape_number in 1:4
             solar_orientation,
         )
 
-        evaporation_pars = EvaporationParameters(;
+        evaporation_pars = AnimalEvaporationParameters(;
             skin_wetness=(endo_input.PCTWET / 100.0),
             insulation_wetness=(endo_input.FURWET / 100.0),
             eye_fraction=(endo_input.PCTEYES / 100.0),

--- a/test/environment.jl
+++ b/test/environment.jl
@@ -3,12 +3,12 @@ using ModelParameters
 using Unitful
 
 environment_pars = EnvironmentalPars(;
-    α_ground=0.8,
-    ϵ_ground=1.0,
-    ϵ_sky=1.0,
+    ground_albedo=0.8,
+    ground_emissivity=1.0,
+    sky_emissivity=1.0,
     elevation=0.0u"m",
     fluid=0,
-    gasfrac=GasFractions(0.2095, 0.0003, 0.79),
+    gas_fractions=GasFractions(0.2095, 0.0003, 0.79),
 )
 env_params = Model(environment_pars)
 environment_pars = stripparams(env_params)
@@ -24,7 +24,7 @@ environment_vars = EnvironmentalVars(;
     atmospheric_pressure=101325.0u"Pa",
     zenith_angle=20.0u"°",
     global_radiation=1000.0u"W/m^2",
-    k_substrate=0.5u"W/m/K",
+    substrate_conductivity=0.5u"W/m/K",
     diffuse_fraction=0.15,
     shade=0.0,
 )

--- a/test/heat_balance.jl
+++ b/test/heat_balance.jl
@@ -1,0 +1,233 @@
+using HeatExchange
+using BiophysicalGeometry
+using ModelParameters
+using Unitful, UnitfulMoles
+using FluidProperties
+using Test
+
+# Parameters from test/data/endoR_input_4_1.csv (Ellipsoid with fur)
+# Shape 4 = Ellipsoid, furmult 1 = with insulation
+shape_pars = Ellipsoid(65.0u"kg", 1000.0u"kg/m^3", 5.0, 5.0)
+fat        = Fat(0.20, 901.0u"kg/m^3")
+
+pven = 0.4
+insulation_pars = InsulationParameters(;
+    dorsal = FibreProperties(;
+        diameter    = 3e-5u"m",
+        length      = 0.0239u"m",
+        density     = 3e7u"1/m^2",
+        depth       = 0.0239u"m",
+        reflectance = 0.2,
+        conductivity = 0.209u"W/m/K",
+    ),
+    ventral = FibreProperties(;
+        diameter    = 1e-5u"m",
+        length      = 0.0139u"m",
+        density     = 1e7u"1/m^2",
+        depth       = 0.0139u"m",
+        reflectance = 0.2,
+        conductivity = 0.209u"W/m/K",
+    ),
+    depth_compressed       = 0.0139u"m",
+    longwave_depth_fraction = 1.0,
+)
+
+# mean-weighted geometry (same as endotherm.jl test)
+mean_ins_depth    = insulation_pars.dorsal.depth    * (1 - pven) + insulation_pars.ventral.depth    * pven
+mean_fibre_diam   = insulation_pars.dorsal.diameter * (1 - pven) + insulation_pars.ventral.diameter * pven
+mean_fibre_density = insulation_pars.dorsal.density * (1 - pven) + insulation_pars.ventral.density  * pven
+fur      = Fur(mean_ins_depth, mean_fibre_diam, mean_fibre_density)
+geometry = Body(shape_pars, CompositeInsulation(fur, fat))
+
+environment_vars = EnvironmentalVars(;
+    air_temperature           = u"K"(20.0u"°C"),
+    reference_air_temperature = u"K"(20.0u"°C"),
+    sky_temperature           = u"K"(10.0u"°C"),
+    ground_temperature        = u"K"(40.0u"°C"),
+    substrate_temperature     = u"K"(30.0u"°C"),
+    bush_temperature          = u"K"(10.0u"°C"),
+    vegetation_temperature    = u"K"(20.0u"°C"),
+    relative_humidity         = 0.05,
+    wind_speed                = 1.0u"m/s",
+    atmospheric_pressure      = 101325.0u"Pa",
+    zenith_angle              = 20.0u"°",
+    substrate_conductivity    = 2.79u"W/m/K",
+    global_radiation          = 500.0u"W/m^2",
+    diffuse_fraction          = 0.15,
+    shade                     = 0.1,
+)
+
+environment_pars = EnvironmentalPars(;
+    ground_albedo        = 0.8,
+    ground_emissivity    = 1.0,
+    sky_emissivity       = 1.0,
+    elevation            = 0.0u"m",
+    fluid                = 0,
+    gas_fractions        = GasFractions(0.2095, 0.000412, 0.7902),
+    convection_enhancement = 1.0,
+)
+
+internal_conduction = InternalConductionParameters(;
+    fat_fraction        = 0.20,
+    flesh_conductivity  = 0.9u"W/m/K",
+    fat_conductivity    = 0.23u"W/m/K",
+    fat_density         = 901.0u"kg/m^3",
+)
+external_conduction = ExternalConductionParameters(; conduction_fraction = 0.3)
+
+radiation_pars = RadiationParameters(;
+    body_absorptivity_dorsal  = 0.8,
+    body_absorptivity_ventral = 0.8,
+    body_emissivity_dorsal    = 0.99,
+    body_emissivity_ventral   = 0.99,
+    sky_view_factor           = 0.5,
+    ground_view_factor        = 0.5,
+    bush_view_factor          = 0.0,
+    ventral_fraction          = pven,
+    solar_orientation         = NormalToSun(),
+)
+
+evaporation_pars = AnimalEvaporationParameters(;
+    skin_wetness        = 0.0005,
+    insulation_wetness  = 0.0005,
+    eye_fraction        = 0.0003,
+    bare_skin_fraction  = 0.0,
+    insulation_fraction = 1.0,
+)
+respiration_pars = RespirationParameters(;
+    oxygen_extraction_efficiency = 0.2,
+    pant                         = 1.0,
+    respiratory_quotient         = 0.8,
+    exhaled_temperature_offset   = 100.0u"K",
+    exhaled_relative_humidity    = 1.0,
+)
+metabolism_pars = MetabolismParameters(;
+    core_temperature    = u"K"(37.0u"°C"),
+    metabolic_heat_flow = 77.6184u"W",
+    q10                 = 2.0,
+    model               = Kleiber(),
+)
+
+traits = HeatExchangeTraits(
+    shape_pars,
+    insulation_pars,
+    external_conduction,
+    internal_conduction,
+    radiation_pars,
+    ConvectionParameters(),
+    evaporation_pars,
+    HydraulicParameters(),
+    respiration_pars,
+    metabolism_pars,
+    SolveMetabolicRateOptions(; respire = true, temperature_error_tolerance = 1e-3u"K", resp_tolerance = 1e-5),
+)
+organism = Organism(geometry, traits)
+
+# Solve iterative model
+endo_out   = solve_metabolic_rate(organism, (; environment_pars, environment_vars), u"K"(34.0u"°C"), u"K"(29.0u"°C"))
+thermoreg  = endo_out.thermoregulation
+Q_gen      = endo_out.energy_flows.generated_heat_flow
+T_core     = thermoreg.core_temperature
+
+# -------------------------------------------------------------------------
+# Replicate the dorsal-side inputs that solve_metabolic_rate packs internally
+# (see solve_metabolic_rate lines ~80–200 in endotherm.jl)
+# -------------------------------------------------------------------------
+dmult = 1.0 - pven                      # 0.6
+vegetation_factor = radiation_pars.sky_view_factor * environment_vars.shade   # 0.5 * 0.1 = 0.05
+sky_factor_ref    = radiation_pars.sky_view_factor - vegetation_factor         # 0.45
+ground_factor_ref = 1.0 - sky_factor_ref - vegetation_factor                  # 0.50
+
+# Dorsal body uses the dorsal insulation depth
+ins_layer_d = Fur(insulation_pars.dorsal.depth, insulation_pars.dorsal.diameter, insulation_pars.dorsal.density)
+body_d      = Body(shape_pars, CompositeInsulation(ins_layer_d, fat))
+
+# Solar for dorsal side — mirrors solve_metabolic_rate solar block
+ep = stripparams(environment_pars)
+absorptivities   = Absorptivities(radiation_pars, ep)
+vf_solar         = ViewFactors(sky_factor_ref, ground_factor_ref, 0.0, 0.0)
+solar_conds      = SolarConditions(environment_vars)
+area_sil         = silhouette_area(geometry, radiation_pars.solar_orientation)
+area_cond_ref    = BiophysicalGeometry.total_area(geometry) * external_conduction.conduction_fraction
+solar_out        = solar(geometry, absorptivities, vf_solar, solar_conds, area_sil, area_cond_ref)
+dorsal_solar     = solar_out.solar_flow > 0.0u"W" ?
+    2.0 * solar_out.direct_flow + solar_out.solar_sky_flow * 2.0 :
+    0.0u"W"
+
+# Dorsal side temperatures from converged solution
+T_skin_d = thermoreg.skin_temperature_dorsal
+T_ins_d  = thermoreg.insulation_temperature_dorsal
+
+# Insulation properties at converged dorsal temperatures
+ins_d = insulation_properties(insulation_pars, T_ins_d * 0.7 + T_skin_d * 0.3, pven)
+
+geometry_vars_d = GeometryVariables(;
+    side                    = :dorsal,
+    conductance_coefficient = 0.0u"W/K",
+    ventral_fraction        = pven,
+    conduction_fraction     = external_conduction.conduction_fraction,
+    longwave_depth_fraction = insulation_pars.longwave_depth_fraction,
+)
+
+# vegetation_temperature is reference_air_temperature in solve_metabolic_rate
+env_d = (;
+    temperature = (
+        air        = environment_vars.air_temperature,
+        sky        = environment_vars.sky_temperature,
+        ground     = environment_vars.ground_temperature,
+        vegetation = environment_vars.reference_air_temperature,
+        bush       = environment_vars.bush_temperature,
+        substrate  = environment_vars.substrate_temperature,
+    ),
+    view_factors = (
+        sky        = sky_factor_ref * 2.0,
+        ground     = 0.0,
+        bush       = 0.0,
+        vegetation = vegetation_factor * 2.0,
+    ),
+    atmos = (
+        relative_humidity    = environment_vars.relative_humidity,
+        wind_speed           = environment_vars.wind_speed,
+        atmospheric_pressure = environment_vars.atmospheric_pressure,
+    ),
+    fluid                  = ep.fluid,
+    solar_flow             = dorsal_solar,
+    gas_fractions          = ep.gas_fractions,
+    convection_enhancement = ep.convection_enhancement,
+)
+
+traits_d = (;
+    fat_conductivity   = internal_conduction.fat_conductivity,
+    flesh_conductivity = internal_conduction.flesh_conductivity,
+    ϵ_body             = radiation_pars.body_emissivity_dorsal,
+    insulation_wetness = evaporation_pars.insulation_wetness,
+    bare_skin_fraction = evaporation_pars.bare_skin_fraction,
+    eye_fraction       = evaporation_pars.eye_fraction,
+    skin_wetness       = evaporation_pars.skin_wetness,
+)
+
+hb_d = heat_balance(
+    T_core, T_skin_d, T_ins_d, Q_gen;
+    body              = body_d,
+    insulation_pars   = insulation_pars,
+    insulation        = ins_d,
+    geometry_vars     = geometry_vars_d,
+    minimum_metabolic_heat = Q_gen, # what should this be?
+    environment_vars  = env_d,
+    traits            = traits_d,
+    resp_pars         = respiration_pars,
+)
+balance = Q_gen + hb_d.solar_heat_flow - 
+    hb_d.radiation_heat_flow - 
+    hb_d.convection_heat_flow - 
+    hb_d.conduction_heat_flow - 
+    hb_d.skin_evaporation_heat_flow -
+    hb_d.insulation_evaporation_heat_flow - 
+    hb_d.respiration_heat_flow - 
+    hb_d.net_metabolic_heat_internal
+
+@test abs(ustrip(u"W", balance)) < 0.01
+# The iterative solver converged T_skin, so residual_skin_temperature must be near zero.
+# residual_energy_balance and residual_internal_conduction use the full-organism Q_gen
+# against per-side losses, so they need not be zero for a one-sided call.
+@test abs(ustrip(u"K", hb_d.residual_skin_temperature)) < 0.01

--- a/test/insulation.jl
+++ b/test/insulation.jl
@@ -1,3 +1,7 @@
+using HeatExchange
+using BiophysicalGeometry
+using ModelParameters
+using Unitful
 
 insulation = InsulationParameters(;
     dorsal=FibreProperties(;

--- a/test/leaf.jl
+++ b/test/leaf.jl
@@ -48,7 +48,7 @@ environment = (; environment_pars, environment_vars)
 leaf_density  = 700.0u"kg/m^3"       # typical mesophyll
 leaf_mass     = 0.2u"g" |> u"kg"     # a small leaf
 leaf_shape    = Plate(leaf_mass, leaf_density, 1.0, 100.0)   # b=1 (square), c=100 (thin)
-leaf_body     = Body(leaf_shape, Naked(); characteristic_dimension=ShortestDimension(0.7))
+leaf_body     = Body(leaf_shape, Naked())
 
 # Traits
 leaf_traits = HeatExchangeTraits(
@@ -68,7 +68,7 @@ leaf_traits = HeatExchangeTraits(
         ventral_fraction=0.5,
         solar_orientation=Intermediate(),
     ),
-    ConvectionParameters(),
+    ConvectionParameters(; characteristic_dimension_formula=ScaledDimension(0.7, :width_skin)),
     LeafEvaporationParameters(;
         abaxial_vapour_conductance=0.3u"mol/m^2/s",    # stomata open
         adaxial_vapour_conductance=0.0u"mol/m^2/s",
@@ -116,7 +116,7 @@ closed_traits = HeatExchangeTraits(
         ventral_fraction=0.5,
         solar_orientation=Intermediate(),
     ),
-    ConvectionParameters(),
+    ConvectionParameters(; characteristic_dimension_formula=ScaledDimension(0.7, :width_skin)),
     closed_pars,
     HydraulicParameters(; water_potential=0.0u"J/kg"),
     RespirationParameters(),

--- a/test/leaf.jl
+++ b/test/leaf.jl
@@ -116,7 +116,8 @@ closed_traits = HeatExchangeTraits(
         ventral_fraction=0.5,
         solar_orientation=Intermediate(),
     ),
-    ConvectionParameters(; characteristic_dimension_formula=ScaledDimension(0.7, :width_skin)),
+    ConvectionParameters(; 
+    characteristic_dimension_formula=ScaledDimension(0.7, :width_skin)), # Campbell and Norman 1998 suggests 0.7 for leaf boundary layer
     closed_pars,
     HydraulicParameters(; water_potential=0.0u"J/kg"),
     RespirationParameters(),

--- a/test/leaf.jl
+++ b/test/leaf.jl
@@ -1,0 +1,144 @@
+using HeatExchange
+using BiophysicalGeometry
+using ModelParameters
+using Unitful, UnitfulMoles
+using Test
+
+# Environment
+air_temperature       = (273.15 + 25.0)u"K"
+sky_temperature       = (273.15 + 10.0)u"K"
+ground_temperature    = (273.15 + 35.0)u"K"
+substrate_temperature = air_temperature
+relative_humidity     = 0.40
+wind_speed            = 1.0u"m/s"
+atmospheric_pressure  = 101325.0u"Pa"
+zenith_angle          = 30.0u"°"
+global_radiation      = 800.0u"W/m^2"
+substrate_conductivity = 0.5u"W/m/K"
+
+gas_fractions = GasFractions(0.2095, 0.0003, 0.79)
+
+environment_pars = EnvironmentalPars(;
+    ground_albedo=0.15,
+    ground_emissivity=0.95,
+    sky_emissivity=1.0,
+    elevation=0.0u"m",
+    fluid=0,
+    gas_fractions,
+)
+
+environment_vars = EnvironmentalVars(;
+    air_temperature,
+    sky_temperature,
+    ground_temperature,
+    substrate_temperature,
+    relative_humidity,
+    wind_speed,
+    atmospheric_pressure,
+    substrate_conductivity,
+    zenith_angle,
+    global_radiation,
+    diffuse_fraction=0.15,
+    shade=0.0,
+)
+
+environment = (; environment_pars, environment_vars)
+
+# Leaf body: thin Plate (5 cm × 5 cm × 0.5 mm), ShortestDimension(0.7) after Gates 1980
+leaf_density  = 700.0u"kg/m^3"       # typical mesophyll
+leaf_mass     = 0.2u"g" |> u"kg"     # a small leaf
+leaf_shape    = Plate(leaf_mass, leaf_density, 1.0, 100.0)   # b=1 (square), c=100 (thin)
+leaf_body     = Body(leaf_shape, Naked(); characteristic_dimension=ShortestDimension(0.7))
+
+# Traits
+leaf_traits = HeatExchangeTraits(
+    leaf_shape,
+    InsulationParameters(),                                    # no insulation
+    ExternalConductionParameters(; conduction_fraction=0.0),   # leaf not on substrate
+    InternalConductionParameters(; flesh_conductivity=100.0u"W/m/K"),  # near-isothermal
+    RadiationParameters(;
+        body_absorptivity_dorsal=0.5,
+        body_absorptivity_ventral=0.5,
+        body_emissivity_dorsal=0.97,
+        body_emissivity_ventral=0.97,
+        sky_view_factor=0.5,
+        ground_view_factor=0.5,
+        vegetation_view_factor=0.0,
+        bush_view_factor=0.0,
+        ventral_fraction=0.5,
+        solar_orientation=Intermediate(),
+    ),
+    ConvectionParameters(),
+    LeafEvaporationParameters(;
+        abaxial_vapour_conductance=0.3u"mol/m^2/s",    # stomata open
+        adaxial_vapour_conductance=0.0u"mol/m^2/s",
+        cuticular_conductance=0.01u"mol/m^2/s",
+    ),
+    HydraulicParameters(; water_potential=0.0u"J/kg"),
+    RespirationParameters(),
+    MetabolismParameters(; metabolic_heat_flow=0.0u"W", model=PlantDarkRespiration()),
+    SolveMetabolicRateOptions(),
+)
+
+leaf = Organism(leaf_body, leaf_traits)
+
+# --- Tests ---
+
+T_leaf = (273.15 + 25.0)u"K"
+out = heat_balance(T_leaf, leaf, environment)
+
+@test isfinite(ustrip(out.heat_balance))        # heat_balance is finite
+@test isfinite(ustrip(out.surface_temperature)) # surface temperature computed
+
+# With stomata open, transpiration should be positive under subsaturated air
+@test out.mass_balance.transpiration_mass > 0.0u"g/s"
+
+# Closing stomata (both conductances → 0) should reduce transpiration to near-cuticular only
+closed_pars = LeafEvaporationParameters(;
+    abaxial_vapour_conductance=0.0u"mol/m^2/s",
+    adaxial_vapour_conductance=0.0u"mol/m^2/s",
+    cuticular_conductance=0.01u"mol/m^2/s",
+)
+closed_traits = HeatExchangeTraits(
+    leaf_shape,
+    InsulationParameters(),
+    ExternalConductionParameters(; conduction_fraction=0.0),
+    InternalConductionParameters(; flesh_conductivity=100.0u"W/m/K"),
+    RadiationParameters(;
+        body_absorptivity_dorsal=0.5,
+        body_absorptivity_ventral=0.5,
+        body_emissivity_dorsal=0.97,
+        body_emissivity_ventral=0.97,
+        sky_view_factor=0.5,
+        ground_view_factor=0.5,
+        vegetation_view_factor=0.0,
+        bush_view_factor=0.0,
+        ventral_fraction=0.5,
+        solar_orientation=Intermediate(),
+    ),
+    ConvectionParameters(),
+    closed_pars,
+    HydraulicParameters(; water_potential=0.0u"J/kg"),
+    RespirationParameters(),
+    MetabolismParameters(; metabolic_heat_flow=0.0u"W", model=PlantDarkRespiration()),
+    SolveMetabolicRateOptions(),
+)
+leaf_closed = Organism(leaf_body, closed_traits)
+out_closed = heat_balance(T_leaf, leaf_closed, environment)
+
+@test out_closed.mass_balance.transpiration_mass < out.mass_balance.transpiration_mass
+
+# solve_temperature should converge to a steady state
+T_eq = solve_temperature(leaf, environment)
+@test isfinite(ustrip(T_eq))
+@test 273.0u"K" < T_eq < 370.0u"K"
+
+# At steady state, heat_balance should be near zero
+eq_out = heat_balance(T_eq, leaf, environment)
+@test abs(ustrip(u"W", eq_out.heat_balance)) < 1e-2   # within 0.01 W of zero
+
+# PlantDarkRespiration: metabolic rate at 25°C should be positive and small
+dark_resp = PlantDarkRespiration()
+resp_rate = metabolic_rate(dark_resp, leaf_mass, T_leaf)
+@test resp_rate > 0.0u"W"
+@test resp_rate < 1.0u"W"   # a tiny leaf

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ end
 
 @safetestset "biophysics" begin include("biophysics.jl") end
 @safetestset "ectotherm" begin include("ectotherm.jl") end
+@safetestset "leaf" begin include("leaf.jl") end
 @safetestset "endotherm" begin include("endotherm.jl") end
 @safetestset "ellipsoid" begin include("ellipsoid.jl") end
 @safetestset "metabolism" begin include("metabolism.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ using Test
     Aqua.test_deps_compat(HeatExchange)
 end
 
+@safetestset "biophysics" begin include("biophysics.jl") end
 @safetestset "ectotherm" begin include("ectotherm.jl") end
 @safetestset "endotherm" begin include("endotherm.jl") end
 @safetestset "ellipsoid" begin include("ellipsoid.jl") end


### PR DESCRIPTION
This PR generalises the heat_balance function for leaves and endotherms. This function was originally called "ectotherm" and computed all the terms in the heat budget given the properties of a bare-skinned organism and its body temperature. There is a need to generalise it for leaves and for the endotherm scenario so that optimisers (e.g. IPOPT, the target case at present) can be used.

For leaves we need a new struct to hold the required parameters, LeafEvaporationParameters (src/traits.jl) and the original EvaporationParameters struct is renamed AnimalEvaporationParameters. A new dispatch of metabolic rate for plants is added for the plant method of heat_balance: PlantDarkRespiration (src/metabolism.jl) — Arrhenius-scaled, mass-based dark respiration equation following Reich et al. (2006), usable as the metabolic model for leaves. We also need to update the strategy for defining characteristic dimensions - leaves may best be characterised by leaf width rather than cube root of the volume which is the current approach.

This PR implements these changes and reduces some code duplication. A subsequent refactor will generalise it further and restructure the files and functions according to insulated/uninsulated and solving for temperature vs. solving for metabolic rate.