### PR TITLE
Add SmoothingStrategy for differentiable conditionals

### DIFF
--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -107,6 +107,10 @@ export NLPStrategy, WeightedMeanNLP, MultiSidedNLP
 export WeightedMeanNLPPacked, MultiSidedNLPPacked
 export nlp_pack, nlp_residuals, nlp_assemble_output
 
+export SmoothingStrategy, HardBound, SmoothBound
+export safe_abs, safe_relu, safe_step, safe_max, safe_min, safe_clamp
+
+include("smoothing.jl")
 include("rootfinding.jl")
 include("organism.jl")
 include("traits.jl")

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -203,6 +203,7 @@ function convection(;
     gas_fractions::GasFractions=GasFractions(),
     convection_enhancement=1.0,
     characteristic_dimension_formula::CharacteristicDimFormula=VolumeCubeRoot(),
+    smoothing::SmoothingStrategy=HardBound(),
 )
     thermal_expansion_coefficient = 1 / air_temperature
     characteristic_dim = characteristic_dimension(characteristic_dimension_formula, body)
@@ -230,11 +231,14 @@ function convection(;
     else
         schmidt_number = dynamic_viscosity / (fluid_density * vapour_diffusivity)
     end
-    temperature_difference = surface_temperature - air_temperature
-    if temperature_difference <= 0.0u"K" # stability check - avoiding zero
-        temperature_difference = temperature_difference + 0.00001u"K"
-    end
-    grashof_number = abs(((fluid_density^2) * thermal_expansion_coefficient * Unitful.gn * (characteristic_dim^3) * temperature_difference) / (dynamic_viscosity^2))
+    # |ΔT| in the Grashof number. HardBound uses exact `abs`; SmoothBound replaces
+    # it with sqrt(ΔT² + (ε·scale)²) so Enzyme reverse-mode does not see a kink at
+    # ΔT = 0 (which produced NaN gradients when the optimiser landed there).
+    # scale = 1 K — typical ΔT during simulation is 1–50 K, so ε·1K stays below
+    # the meaningful signal at any sensible ε.
+    ΔT = surface_temperature - air_temperature
+    temperature_difference = safe_abs(smoothing, ΔT; scale=1.0u"K")
+    grashof_number = ((fluid_density^2) * thermal_expansion_coefficient * Unitful.gn * (characteristic_dim^3) * temperature_difference) / (dynamic_viscosity^2)
     reynolds_number = fluid_density * wind_speed * characteristic_dim /dynamic_viscosity
     free_nusselt_number = nusselt_free(body.shape, grashof_number, prandtl_number)
     free_heat_transfer_coefficient = (free_nusselt_number * fluid_conductivity) / characteristic_dim # heat transfer coefficient, free

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -365,6 +365,7 @@ function heat_balance(
     k_flesh = traits.flesh_conductivity,
     pant = resp_pars.pant,
     skin_wetness = traits.skin_wetness,
+    smoothing::SmoothingStrategy = HardBound(),
 )
     (; side, conductance_coefficient, conduction_fraction, longwave_depth_fraction) = geometry_vars
     (;
@@ -404,6 +405,7 @@ function heat_balance(
         fluid,
         gas_fractions,
         convection_enhancement,
+        smoothing,
     )
     heat_transfer_coefficient = conv.heat_transfer_coefficient.combined
 
@@ -446,7 +448,7 @@ function heat_balance(
     # Insulation surface evaporation (conditional on fixed params, outside differentiable path)
     insulation_evaporation_heat_flow = _insulation_evaporation(
         conv, atmos_local, area_convection, insulation_temperature, air_temperature,
-        insulation_wetness, insulation.insulation_test; gas_fractions)
+        insulation_wetness, insulation.insulation_test; gas_fractions, smoothing)
 
     # -------------------------------------------------------------------------
     # Radiation exchange (coefficients linearised at radiant_temp, flows use radiant_temp)

--- a/src/insulated/insulation.jl
+++ b/src/insulated/insulation.jl
@@ -137,33 +137,33 @@ function insulation_properties(insulation::InsulationParameters, insulation_temp
 
     fibres = BodyRegionValues(avg_fibres, dorsal, ventral_adj)
 
-    # Always compute insulation thermal parameters, then mask to zero when
-    # insulation is absent. The previous if/else branched on `insulation_test`
-    # but produced different concrete unit types in each arm: the literal
-    # `0.0u"W/m/K"` has FreeUnits ordering different from the unit tuple
-    # built by `insulation_thermal_conductivity`'s arithmetic, so the join
-    # was a Union — which forces Enzyme into typeunstablerules.jl.
-    avg  = insulation_thermal_conductivity(fibres.average, air_conductivity)
-    dors = insulation_thermal_conductivity(fibres.dorsal,  air_conductivity)
-    vent = insulation_thermal_conductivity(fibres.ventral, air_conductivity)
-    vent_compressed = insulation_thermal_conductivity(fibres.ventral, air_conductivity; depth=depth_compressed)
-    mask = safe_step(smoothing, insulation_test; scale=1.0e-6u"m")
-    conductivities = BodyRegionValues(
-        mask * avg.effective_conductivity,
-        mask * dors.effective_conductivity,
-        mask * vent.effective_conductivity,
-    )
-    absorption_coefficients = BodyRegionValues(
-        mask * avg.absorption_coefficient,
-        mask * dors.absorption_coefficient,
-        mask * vent.absorption_coefficient,
-    )
-    optical_thickness = BodyRegionValues(
-        mask * avg.optical_thickness_factor,
-        mask * dors.optical_thickness_factor,
-        mask * vent.optical_thickness_factor,
-    )
-    conductivity_compressed = mask * vent_compressed.effective_conductivity
+    # Bare-skin (zero density / depth / length) makes `insulation_thermal_conductivity`
+    # divide by zero, so we cannot use a `mask * value` blend — IEEE keeps NaN
+    # through `0 * NaN`. The inner function is now canonical-typed across both
+    # arms (W/m/K, m^-1, NoUnits), so the if/else does not Union-typed-return
+    # and remains AD-friendly. `smoothing` stays in the signature for API
+    # consistency with other call sites.
+    conductivity_compressed = 0.0u"W/m/K"
+    if insulation_test <= 0.0u"m"
+        conductivities = BodyRegionValues(0.0u"W/m/K", 0.0u"W/m/K", 0.0u"W/m/K")
+        absorption_coefficients = BodyRegionValues(0.0u"m^-1", 0.0u"m^-1", 0.0u"m^-1")
+        optical_thickness = BodyRegionValues(0.0, 0.0, 0.0)
+    else
+        avg  = insulation_thermal_conductivity(fibres.average, air_conductivity)
+        dors = insulation_thermal_conductivity(fibres.dorsal,  air_conductivity)
+        vent = insulation_thermal_conductivity(fibres.ventral, air_conductivity)
+        vent_compressed = insulation_thermal_conductivity(fibres.ventral, air_conductivity; depth=depth_compressed)
+        conductivities = BodyRegionValues(
+            avg.effective_conductivity, dors.effective_conductivity, vent.effective_conductivity,
+        )
+        absorption_coefficients = BodyRegionValues(
+            avg.absorption_coefficient, dors.absorption_coefficient, vent.absorption_coefficient,
+        )
+        optical_thickness = BodyRegionValues(
+            avg.optical_thickness_factor, dors.optical_thickness_factor, vent.optical_thickness_factor,
+        )
+        conductivity_compressed = vent_compressed.effective_conductivity
+    end
 
     return InsulationProperties(
         fibres,

--- a/src/insulated/insulation.jl
+++ b/src/insulated/insulation.jl
@@ -119,8 +119,9 @@ Compute parameters for heat conduction and longwave radiation through insulation
 - `insulation_test`: Bare-skin test parameter (zero if no insulation).
 - `conductivity_compressed`: Conductivity of compressed ventral insulation (W/m/K).
 """
-function insulation_properties(insulation::InsulationParameters, insulation_temperature, ventral_fraction)
-    (; dorsal, ventral, depth_compressed) = stripparams(insulation)
+function insulation_properties(insulation::InsulationParameters, insulation_temperature, ventral_fraction;
+                               smoothing::SmoothingStrategy=HardBound())
+    (; dorsal, ventral, depth_compressed) = insulation
 
     # Physical constants
     air_conductivity = dry_air_properties(insulation_temperature).thermal_conductivity
@@ -136,29 +137,33 @@ function insulation_properties(insulation::InsulationParameters, insulation_temp
 
     fibres = BodyRegionValues(avg_fibres, dorsal, ventral_adj)
 
-    # Compute insulation thermal parameters for each region
-    conductivity_compressed = 0.0u"W/m/K"
-    if insulation_test <= 0.0u"m"
-        conductivities = BodyRegionValues(0.0u"W/m/K", 0.0u"W/m/K", 0.0u"W/m/K")
-        absorption_coefficients = BodyRegionValues(0.0u"m^-1", 0.0u"m^-1", 0.0u"m^-1")
-        optical_thickness = BodyRegionValues(0.0, 0.0, 0.0)
-    else
-        avg = insulation_thermal_conductivity(fibres.average, air_conductivity)
-        dors = insulation_thermal_conductivity(fibres.dorsal, air_conductivity)
-        vent = insulation_thermal_conductivity(fibres.ventral, air_conductivity)
-        conductivities = BodyRegionValues(
-            avg.effective_conductivity, dors.effective_conductivity, vent.effective_conductivity
-        )
-        absorption_coefficients = BodyRegionValues(
-            avg.absorption_coefficient, dors.absorption_coefficient, vent.absorption_coefficient
-        )
-        optical_thickness = BodyRegionValues(
-            avg.optical_thickness_factor, dors.optical_thickness_factor, vent.optical_thickness_factor
-        )
-        # Compressed ventral insulation conductivity
-        vent_compressed = insulation_thermal_conductivity(fibres.ventral, air_conductivity; depth=depth_compressed)
-        conductivity_compressed = vent_compressed.effective_conductivity
-    end
+    # Always compute insulation thermal parameters, then mask to zero when
+    # insulation is absent. The previous if/else branched on `insulation_test`
+    # but produced different concrete unit types in each arm: the literal
+    # `0.0u"W/m/K"` has FreeUnits ordering different from the unit tuple
+    # built by `insulation_thermal_conductivity`'s arithmetic, so the join
+    # was a Union — which forces Enzyme into typeunstablerules.jl.
+    avg  = insulation_thermal_conductivity(fibres.average, air_conductivity)
+    dors = insulation_thermal_conductivity(fibres.dorsal,  air_conductivity)
+    vent = insulation_thermal_conductivity(fibres.ventral, air_conductivity)
+    vent_compressed = insulation_thermal_conductivity(fibres.ventral, air_conductivity; depth=depth_compressed)
+    mask = safe_step(smoothing, insulation_test; scale=1.0e-6u"m")
+    conductivities = BodyRegionValues(
+        mask * avg.effective_conductivity,
+        mask * dors.effective_conductivity,
+        mask * vent.effective_conductivity,
+    )
+    absorption_coefficients = BodyRegionValues(
+        mask * avg.absorption_coefficient,
+        mask * dors.absorption_coefficient,
+        mask * vent.absorption_coefficient,
+    )
+    optical_thickness = BodyRegionValues(
+        mask * avg.optical_thickness_factor,
+        mask * dors.optical_thickness_factor,
+        mask * vent.optical_thickness_factor,
+    )
+    conductivity_compressed = mask * vent_compressed.effective_conductivity
 
     return InsulationProperties(
         fibres,

--- a/src/insulated/skin_and_insulation_temperature.jl
+++ b/src/insulated/skin_and_insulation_temperature.jl
@@ -1,14 +1,26 @@
 function _insulation_evaporation(conv, atmos, area_convection, insulation_temperature, air_temperature,
-                                  insulation_wetness, insulation_test; gas_fractions)
-    insulation_wetness > 0 && insulation_test > 0.0u"m" || return 0.0u"W"
+                                  insulation_wetness, insulation_test;
+                                  gas_fractions, smoothing::SmoothingStrategy=HardBound())
+    # Always evaluate the evaporation expression and gate by a numeric mask. With
+    # an early `|| return 0.0u"W"` the function's return type becomes a Union of
+    # {computed Quantity, literal 0.0u"W"}, which Enzyme's reverse-mode flags as
+    # EnzymeRuntimeActivityError. `safe_step` collapses to the exact ternary mask
+    # under HardBound and to a smooth Heaviside under SmoothBound.
     evap_pars_ins = AnimalEvaporationParameters(;
         skin_wetness = insulation_wetness,
         eye_fraction = 0.0,
         bare_skin_fraction = 1.0,
     )
     mass_ins = TransferCoefficients(conv.mass_transfer_coefficient.combined, conv.mass_transfer_coefficient.combined, conv.mass_transfer_coefficient.forced)
-    evaporation(evap_pars_ins, mass_ins, atmos, area_convection, insulation_temperature, air_temperature;
-                gas_fractions).evaporation_heat_flow
+    flow = evaporation(evap_pars_ins, mass_ins, atmos, area_convection, insulation_temperature, air_temperature;
+                       gas_fractions).evaporation_heat_flow
+    # scale=0.01 for wetness (typical 1e-3–5e-2 fraction);
+    # scale=1e-6u"m" for insulation_test — well below any nonzero physical value
+    # (≥3e-6 m for the thinnest realistic fur), so the Heaviside is essentially
+    # a step except in the structurally-zero "naked" case.
+    mask = safe_step(smoothing, insulation_wetness; scale=0.01) *
+           safe_step(smoothing, insulation_test;    scale=1.0e-6u"m")
+    return mask * flow
 end
 
 function _insulation_conductivity(insulation, insulation_pars, side, insulation_temperature, skin_temperature, longwave_depth_fraction, σ)

--- a/src/nlp_interface.jl
+++ b/src/nlp_interface.jl
@@ -47,8 +47,8 @@ BiophysicalBehaviour.jl code) using only HeatExchange functions.
 
 Returns a `WeightedMeanNLPPacked` whose `p` field carries the packed parameters.
 """
-function nlp_pack(::WeightedMeanNLP, organism::Organism, environment, initial_skin_temperature, 
-        initial_insulation_temperature)
+function nlp_pack(::WeightedMeanNLP, organism::Organism, environment, initial_skin_temperature,
+        initial_insulation_temperature; smoothing::SmoothingStrategy=HardBound())
     env_pars = stripparams(environment.environment_pars)
     env_vars = environment.environment_vars
 
@@ -191,6 +191,7 @@ function nlp_pack(::WeightedMeanNLP, organism::Organism, environment, initial_sk
         substrate_conductivity = env_vars.substrate_conductivity,
         conduction_depth       = env_pars.conduction_depth,
         insulation_props_init,
+        smoothing,
     )
     return WeightedMeanNLPPacked(p)
 end
@@ -208,7 +209,8 @@ guesses and per-side packed structures. No physics is duplicated.
 
 Returns a `MultiSidedNLPPacked` whose `p` field carries the packed parameters.
 """
-function nlp_pack(::MultiSidedNLP, organism::Organism, environment, initial_skin_temperature, initial_insulation_temperature)
+function nlp_pack(::MultiSidedNLP, organism::Organism, environment, initial_skin_temperature, initial_insulation_temperature;
+                  smoothing::SmoothingStrategy=HardBound())
     env_pars = stripparams(environment.environment_pars)
     env_vars = environment.environment_vars
 
@@ -255,6 +257,7 @@ function nlp_pack(::MultiSidedNLP, organism::Organism, environment, initial_skin
         initial_dorsal_insulation_temperature  = packed.temps_out[1].insulation_temperature,
         initial_ventral_skin_temperature = packed.temps_out[2].skin_temperature,
         initial_ventral_insulation_temperature  = packed.temps_out[2].insulation_temperature,
+        smoothing,
     )
     return MultiSidedNLPPacked(p)
 end
@@ -286,7 +289,8 @@ function nlp_residuals(p::WeightedMeanNLPPacked, core_temperature, skin_temperat
 
     # Recompute temperature-dependent insulation properties
     mean_ins_temperature  = insulation_temperature * 0.7 + skin_temperature * 0.3
-    trial_insulation_props = insulation_properties(trial_ins_pars, mean_ins_temperature, pp.ventral_fraction)
+    trial_insulation_props = insulation_properties(trial_ins_pars, mean_ins_temperature, pp.ventral_fraction;
+                                                   smoothing = pp.smoothing)
 
     # Update conductance coefficient for new body size
     trial_conduction_area  = BiophysicalGeometry.total_area(trial_body) * pp.ext_cond.conduction_fraction * 2
@@ -305,6 +309,7 @@ function nlp_residuals(p::WeightedMeanNLPPacked, core_temperature, skin_temperat
         k_flesh,
         pant,
         skin_wetness,
+        smoothing        = pp.smoothing,
     )
 
     return (;
@@ -353,8 +358,8 @@ function nlp_residuals(p::MultiSidedNLPPacked, core_temperature, dorsal_skin_tem
     trial_body_v = _nlp_rebuild_side_body(pp.body_shape, pp.body_is_sphere, pp.fat, pp.ins_pars.ventral, insulation_depth, aspect_ratio)
 
     # Per-side insulation properties at current temperatures
-    trial_ins_props_d = insulation_properties(trial_ins_pars, dorsal_insulation_temperature * 0.7 + dorsal_skin_temperature * 0.3, pp.ventral_fraction)
-    trial_ins_props_v = insulation_properties(trial_ins_pars, ventral_insulation_temperature * 0.7 + ventral_skin_temperature * 0.3, pp.ventral_fraction)
+    trial_ins_props_d = insulation_properties(trial_ins_pars, dorsal_insulation_temperature * 0.7 + dorsal_skin_temperature * 0.3, pp.ventral_fraction; smoothing = pp.smoothing)
+    trial_ins_props_v = insulation_properties(trial_ins_pars, ventral_insulation_temperature * 0.7 + ventral_skin_temperature * 0.3, pp.ventral_fraction; smoothing = pp.smoothing)
 
     # Update ventral conductance coefficient for new body size (dorsal is always 0)
     trial_cond_area_v   = BiophysicalGeometry.total_area(trial_body_v) * pp.ext_cond.conduction_fraction * 2
@@ -371,6 +376,7 @@ function nlp_residuals(p::MultiSidedNLPPacked, core_temperature, dorsal_skin_tem
         traits           = pp.side_traits_d,
         resp_pars        = pp.resp_pars,
         k_flesh, pant, skin_wetness,
+        smoothing        = pp.smoothing,
     )
     balance_v = heat_balance(
         core_temperature, ventral_skin_temperature, ventral_insulation_temperature, metabolic_heat_flow;
@@ -382,6 +388,7 @@ function nlp_residuals(p::MultiSidedNLPPacked, core_temperature, dorsal_skin_tem
         traits           = pp.side_traits_v,
         resp_pars        = pp.resp_pars,
         k_flesh, pant, skin_wetness,
+        smoothing        = pp.smoothing,
     )
 
     # Dorsal/ventral weights (sky+vegetation facing = dorsal; remainder = ventral)

--- a/src/smoothing.jl
+++ b/src/smoothing.jl
@@ -1,0 +1,104 @@
+"""
+    SmoothingStrategy
+
+Policy for handling kinks (`abs`, `max(x, 0)`, branchy `> 0` masks, `clamp`) so that
+forward simulation gets exact piecewise behaviour while automatic differentiation gets
+well-defined gradients.
+
+Concrete subtypes:
+- [`HardBound`](@ref): exact `abs`, `max`, `clamp`, ternary masks.
+- [`SmoothBound`](@ref): replace each kink with a `sqrt(x² + ε²)`-based smoothing.
+
+Generic helpers dispatching on the strategy:
+- [`safe_abs`](@ref) — smooth `|x|`
+- [`safe_relu`](@ref) — smooth `max(x, 0)`
+- [`safe_step`](@ref) — smooth Heaviside step at 0 (returns ≈1 for x>0, ≈0 for x<0)
+- [`safe_max`](@ref) / [`safe_min`](@ref) / [`safe_clamp`](@ref)
+"""
+abstract type SmoothingStrategy end
+
+"""
+    HardBound() <: SmoothingStrategy
+
+Use exact `abs`, `max`, `clamp` and ternary masks. Correct values, fast, but introduces
+gradient kinks at singular points that break Enzyme's reverse-mode pass.
+"""
+struct HardBound <: SmoothingStrategy end
+
+"""
+    SmoothBound(ε) <: SmoothingStrategy
+
+`ε` is a **dimensionless relative tolerance** in roughly `[0, 1]`. Each helper accepts
+an optional `scale` keyword giving the natural magnitude of the input at that call
+site; the actual smoothing window has size `ε · scale`. So `ε` is a single knob the
+user tunes (default `1e-3`) while every call site bakes in its own physical scale.
+
+Sweet spot: `ε = 1e-3` to `1e-2`. At `ε ≪ 1e-6` the smoothing collapses below Float64
+precision near the kink; at `ε ≳ 1e-1` the smoothing window starts to bias
+`safe_step` / `safe_relu` outputs noticeably away from `{0, 1}`.
+"""
+struct SmoothBound{T<:Real} <: SmoothingStrategy
+    ε::T
+end
+
+SmoothBound() = SmoothBound(1.0e-3)
+
+# --- helpers ---------------------------------------------------------------
+#
+# Each helper takes `scale` as a kwarg with default `oneunit(x)` (or `oneunit(a-b)`
+# for two-arg helpers). Pass an explicit `scale` when the input's natural magnitude
+# differs from `oneunit` (e.g. an unboxed Float64 wetness in [0, 0.05]; a Quantity
+# in metres whose typical nonzero value is 1e-4 m). Smoothing window = ε · scale.
+
+"""
+    safe_abs(s::SmoothingStrategy, x; scale=oneunit(x))
+
+`abs(x)` (HardBound) or `sqrt(x² + (ε·scale)²)` (SmoothBound).
+The smoothing only deviates from `|x|` when `|x| ≲ ε·scale`, so `safe_abs` is
+robust to a small mismatch between `scale` and the actual magnitude of `x`.
+"""
+safe_abs(::HardBound, x; scale=oneunit(x))    = abs(x)
+safe_abs(s::SmoothBound, x; scale=oneunit(x)) = sqrt(x*x + (s.ε * scale)^2)
+
+"""
+    safe_relu(s::SmoothingStrategy, x; scale=oneunit(x))
+
+`max(x, 0)` (HardBound) or `(x + safe_abs(s, x; scale)) / 2` (SmoothBound).
+"""
+safe_relu(::HardBound, x; scale=oneunit(x))    = max(x, zero(x))
+safe_relu(s::SmoothBound, x; scale=oneunit(x)) = (x + safe_abs(s, x; scale)) / 2
+
+"""
+    safe_step(s::SmoothingStrategy, x; scale=oneunit(x))
+
+Heaviside step at 0 — `1.0` if `x > 0` else `0.0` (HardBound), or a smooth
+transition centred on `x = 0` with window width `ε·scale` (SmoothBound).
+Pick `scale` so that `ε·scale` is well below the smallest "meaningfully positive"
+value of `x` you expect.
+"""
+safe_step(::HardBound, x; scale=oneunit(x))    = x > zero(x) ? 1.0 : 0.0
+safe_step(s::SmoothBound, x; scale=oneunit(x)) = (1.0 + x / safe_abs(s, x; scale)) / 2
+
+"""
+    safe_max(s::SmoothingStrategy, a, b; scale=oneunit(a-b))
+
+`max(a, b)` (HardBound) or `(a + b + safe_abs(s, a - b; scale)) / 2` (SmoothBound).
+"""
+safe_max(::HardBound, a, b; scale=oneunit(a-b))    = max(a, b)
+safe_max(s::SmoothBound, a, b; scale=oneunit(a-b)) = (a + b + safe_abs(s, a - b; scale)) / 2
+
+"""
+    safe_min(s::SmoothingStrategy, a, b; scale=oneunit(a-b))
+
+`min(a, b)` (HardBound) or `(a + b - safe_abs(s, a - b; scale)) / 2` (SmoothBound).
+"""
+safe_min(::HardBound, a, b; scale=oneunit(a-b))    = min(a, b)
+safe_min(s::SmoothBound, a, b; scale=oneunit(a-b)) = (a + b - safe_abs(s, a - b; scale)) / 2
+
+"""
+    safe_clamp(s::SmoothingStrategy, x, lo, hi; scale=oneunit(x))
+
+`clamp(x, lo, hi)` (HardBound) or smoothed via `safe_max(s, lo, safe_min(s, hi, x))`.
+"""
+safe_clamp(s::SmoothingStrategy, x, lo, hi; scale=oneunit(x)) =
+    safe_max(s, lo, safe_min(s, hi, x; scale); scale)


### PR DESCRIPTION
This could live in another package one day maybe, but can be here now to solve immediate autodiff problems with hard bounds.

Introduces `HardBound`/`SmoothBound` policy types so call sites that rely on > 0 conditionals, abs, max, or clamp can opt into a sqrt-based smoothing without changing the results for `HardBound`.

- src/smoothing.jl: SmoothingStrategy + HardBound + SmoothBound{T} with `safe_abs`, `safe_relu`, `safe_step`, `safe_max`, `safe_min`, `safe_clamp`. Each helper takes a per-call-site `scale` kwarg; SmoothBound's smoothing window is `ε * scale`. Default ε = 1e-3 (dimensionless relative tolerance).
- biophysics.jl convection: smoothing kwarg; replace branchy ΔT clamp
  + abs(grashof) with safe_abs(smoothing, ΔT; scale = 1.0u"K").
- insulated/insulation.jl insulation_properties: smoothing kwarg; always compute thermal parameters and gate via safe_step(smoothing, insulation_test; scale = 1e-6u"m") instead of branching on insulation_test ≤ 0.
- insulated/skin_and_insulation_temperature.jl _insulation_evaporation: smoothing kwarg; replace short-circuit return with safe_step product over insulation_wetness and insulation_test.
- heat_balance.jl: thread smoothing into convection and _insulation_evaporation.
- nlp_interface.jl: thread smoothing through both nlp_pack methods, store on packed p, and pass into insulation_properties + heat_balance from nlp_residuals.