### PR TITLE
Names, unit canonicalisation and type-stability fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulMoles = "999f2bd7-36bf-5ba7-9bc1-c9473aa75374"
 
 [sources]
-BiophysicalGeometry = {rev = "rename-to-aspect_ratio", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
+BiophysicalGeometry = {rev = "main", url = "https://github.com/BiophysicalEcology/BiophysicalGeometry.jl"}
 FluidProperties = {rev = "main", url = "https://github.com/BiophysicalEcology/FluidProperties.jl"}
 
 [compat]

--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -67,6 +67,8 @@ export solve_metabolic_rate,
     solve_with_insulation!,
     solve_without_insulation!
 
+export ThermoregulationOutput
+
 export insulation_thermal_conductivity, insulation_properties, net_metabolic_heat
 
 export solve_temperatures, mean_skin_temperature, respiration

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -311,10 +311,6 @@ function nusselt_free(shape::Union{Sphere,Ellipsoid}, grashof_number, prandtl_nu
     #  from p.413 Bird et all (1960) Transport Phenomena
     rayleigh_number = (grashof_number ^ (1 / 4)) * (prandtl_number ^ (1 / 3))
     nusselt_number = 2.0 + 0.60 * rayleigh_number
-    if rayleigh_number ≥ 200.0
-        value = (grashof_number^(1/4)) * (prandtl_number^(1/3))
-        println("rayleigh_number = $rayleigh_number, (grashof_number^(1/4)) * (prandtl_number^(1/3)) = $value")
-    end
     return nusselt_number
 end
 

--- a/src/insulated/compressed_radiant_temperature.jl
+++ b/src/insulated/compressed_radiant_temperature.jl
@@ -83,7 +83,7 @@ function compressed_radiant_temperature(
     compression_fraction = (4 * π * insulation.conductivity_compressed * r_compressed) / (r_compressed - r_skin)
     geometric_divisor =
         1 +
-        ((compression_fraction * r_flesh^2.0) / (6 * conductivities.flesh * volume)) +
+        ((compression_fraction * r_flesh^2) / (6 * conductivities.flesh * volume)) +
         ((compression_fraction * r_flesh^3) / (3 * conductivities.fat * volume)) *
         ((r_skin - r_flesh) / (r_flesh * r_skin))
     compressed_insulation_temperature_calc1 = (compression_fraction / geometric_divisor) * core_temperature + conductance_coefficient * substrate_temperature
@@ -134,11 +134,11 @@ function compressed_radiant_temperature(
 
     compression_fraction =
         (3 * insulation.conductivity_compressed * volume * bl_compressed * bs) /
-        ((((3 * ssqg)^0.5)^3) * (bl - bs))
+        ((sqrt(3 * ssqg)^3) * (bl - bs))
     geometric_divisor =
         1 +
         ((compression_fraction * ssqg) / (2 * conductivities.flesh * volume)) +
-        ((compression_fraction * (((3 * ssqg)^0.5)^3)) / (3 * conductivities.fat * volume)) * ((bs - bg) / (bs * bg))
+        ((compression_fraction * (sqrt(3 * ssqg)^3)) / (3 * conductivities.fat * volume)) * ((bs - bg) / (bs * bg))
     compressed_insulation_temperature_calc1 = (compression_fraction / geometric_divisor) * core_temperature + conductance_coefficient * substrate_temperature
     compressed_insulation_temperature_calc2 = conductance_coefficient + compression_fraction / geometric_divisor
     compressed_insulation_temperature = compressed_insulation_temperature_calc1 / compressed_insulation_temperature_calc2

--- a/src/insulated/insulation.jl
+++ b/src/insulated/insulation.jl
@@ -26,70 +26,75 @@ NamedTuple with:
   University of Wisconsin.
 """
 function insulation_thermal_conductivity(fibre::FibreProperties, air_conductivity; depth=nothing)
-    # Allow depth overrides when compressed
-    insulation_depth = isnothing(depth) ? fibre.depth : depth
-    density = fibre.density
+    # Canonicalise inputs to SI before any arithmetic. Otherwise
+    # `density * (fibre.length / insulation_depth)` carries the literal
+    # unit ratio of whichever inputs were used (e.g. mm/m gives a non-
+    # canonical FreeUnits) and every downstream type becomes call-site-
+    # dependent. Caller-side unit choices then make the whole function
+    # type-unstable from a downstream view.
+    insulation_depth = uconvert(u"m", isnothing(depth) ? fibre.depth : depth)
+    fibre_length     = uconvert(u"m", fibre.length)
+    fibre_diameter   = uconvert(u"m", fibre.diameter)
+    density          = uconvert(u"m^-2", fibre.density)
 
     w = 1.0  # weighting factor placeholder
 
     # Effective density (Conley & Porter 1986, p.254)
-    effective_density = density * (fibre.length / insulation_depth)
+    effective_density = density * (fibre_length / insulation_depth)
 
     # Distance between fibre centers (assuming uniform spacing)
     l_unit = 1.0 / sqrt(effective_density)
-    fibre_spacing = l_unit - fibre.diameter
+    fibre_spacing = l_unit - fibre_diameter
 
-    # Initialize variables
-    a_air = r_air = r_fibre = a_fibre = kx = ky = 0.0
+    # Resolve crowded-fibre case (no space between fibres) by re-deriving
+    # density from a hard-packed lattice. After this block both branches
+    # below produce the same unit types — the explicit uconvert casts
+    # restore the canonical FreeUnits ordering after the arithmetic, so
+    # the locals don't end up Union-typed across the join (dimension
+    # matches but FreeUnits ordering can differ, which is invisible to
+    # JET but trips Enzyme's reverse pass).
+    if fibre_spacing < 0.0u"m"
+        l_unit = fibre_diameter
+        effective_density = uconvert(u"m^-2", 1.0 / l_unit^2)
+        density = uconvert(u"m^-2", (effective_density * insulation_depth) / fibre_length)
+        fibre_spacing = l_unit - fibre_diameter
+    end
 
-    # Check for feasible fibre density/diameter
-    if fibre_spacing > 0.0u"m"
-        a_air = (w / 2.0) * (l_unit - fibre.diameter)
-        r_air = u"K*m*W^-1"(l_unit / (air_conductivity * a_air))
-        r_fibre = u"K*m*W^-1"(
-            (
-                (fibre.diameter * air_conductivity) +
-                (l_unit - fibre.diameter) * fibre.conductivity
-            ) / (w * fibre.diameter * fibre.conductivity * air_conductivity),
-        )
-        a_fibre = density * ((u"cm"(fibre.diameter) / 2.0)^2 * π)
-        kx = a_fibre * fibre.conductivity + (1.0 - a_fibre) * air_conductivity
-        ky = (2.0 / r_air) + (1.0 / r_fibre)
+    a_air = (w / 2.0) * (l_unit - fibre_diameter)
+    # Cast r_air, r_fibre to a fixed unit (K·m/W) in both branches —
+    # without the cast the two arms have different FreeUnits orderings,
+    # which makes ky / effective_conductivity / the whole return Union-typed.
+    r_air = if fibre_spacing > 0.0u"m"
+        u"K*m*W^-1"(l_unit / (air_conductivity * a_air))
     else
-        # No space between fibres — recalculate geometry
-        if fibre_spacing < 0.0u"m"
-            l_unit = fibre.diameter
-            effective_density = 1.0 / l_unit^2
-            density = (effective_density * insulation_depth) / fibre.length
-            fibre_spacing = l_unit - fibre.diameter
-        end
-
-        a_air = (w / 2.0) * (l_unit - fibre.diameter)
-        r_air =
-            2.0 /
-            (sqrt(effective_density) * air_conductivity * (l_unit - fibre.diameter) * w)
-        r_fibre =
-            (
-                fibre.diameter * air_conductivity +
-                (l_unit - fibre.diameter) * fibre.conductivity
-            ) / (w * fibre.diameter * fibre.conductivity * air_conductivity)
-        a_fibre = effective_density * ((fibre.diameter / 2.0)^2 * π)
-        kx = a_fibre * fibre.conductivity + (1.0 - a_fibre) * air_conductivity
-        ky = (2.0 / r_air) + (1.0 / r_fibre)
+        u"K*m*W^-1"(2.0 / (sqrt(effective_density) * air_conductivity * (l_unit - fibre_diameter) * w))
     end
-
-    # Effective thermal conductivity (eq. 3-28, Kowalski 1983)
-    effective_conductivity = (ky + kx) / 2.0
-
-    # Ensure air_conductivity < effective_conductivity < fibre.conductivity
-    if effective_conductivity > fibre.conductivity
-        effective_conductivity = fibre.conductivity
-    elseif effective_conductivity < air_conductivity
-        effective_conductivity = air_conductivity
+    r_fibre = u"K*m*W^-1"(
+        ((fibre_diameter * air_conductivity) + (l_unit - fibre_diameter) * fibre.conductivity) /
+        (w * fibre_diameter * fibre.conductivity * air_conductivity)
+    )
+    # `a_fibre` is the dimensionless fibre-cross-section fraction.
+    # NoUnits forces the result to plain Float64; without it the two
+    # branches return Quantity{NoDims, ...} with different FreeUnits
+    # orderings (cm-derived vs m-derived), making the local Union-typed.
+    a_fibre = if fibre_spacing > 0.0u"m"
+        NoUnits(density * (u"cm"(fibre_diameter) / 2.0)^2 * π)
+    else
+        NoUnits(effective_density * (fibre_diameter / 2.0)^2 * π)
     end
+    kx = a_fibre * fibre.conductivity + (1.0 - a_fibre) * air_conductivity
+    ky = (2.0 / r_air) + (1.0 / r_fibre)
+
+    # Effective thermal conductivity (eq. 3-28, Kowalski 1983).
+    # Cast to canonical W/m/K. The clamp below would otherwise mix three
+    # different FreeUnits orderings (computed `(ky+kx)/2`, fibre.conductivity,
+    # air_conductivity) and produce a Union return type.
+    effective_conductivity = u"W/m/K"((ky + kx) / 2.0)
+    effective_conductivity = clamp(effective_conductivity,
+        u"W/m/K"(air_conductivity), u"W/m/K"(fibre.conductivity))
 
     # Absorption and optical parameters
-    absorption_coefficient = (0.67 / π) * u"m^-2"(effective_density) * u"m"(fibre.diameter)
+    absorption_coefficient = (0.67 / π) * u"m^-2"(effective_density) * u"m"(fibre_diameter)
     optical_thickness_factor = absorption_coefficient * u"m"(insulation_depth)
 
     return (; effective_conductivity, absorption_coefficient, optical_thickness_factor)

--- a/src/insulated/insulation_radiant_temperature.jl
+++ b/src/insulated/insulation_radiant_temperature.jl
@@ -320,13 +320,13 @@ function insulation_radiant_temperature(
             (coeffs.sky + coeffs.bush + coeffs.vegetation + coeffs.ground) *
             ((numerator_divisor / radiative_divisor) + ((compressed_insulation_temperature * compressed_conductance) / radiative_divisor))
         ins_calc2 =
-            ((3 * volume * bs) / ((((3 * ssqg)^0.5)^3) * geometric_divisor)) *
+            ((3 * volume * bs) / ((sqrt(3 * ssqg)^3) * geometric_divisor)) *
             (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc3 =
             heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
-            (3 * volume * bs * uncompressed_conductance) / ((((3 * ssqg)^0.5)^3) * geometric_divisor) +
+            (3 * volume * bs * uncompressed_conductance) / ((sqrt(3 * ssqg)^3) * geometric_divisor) +
             (coeffs.sky + coeffs.bush + coeffs.vegetation + coeffs.ground) *
             ((((insulation_conductivity * bl) / (bl - br)) * (1 - conduction_fraction)) / radiative_divisor) +
             heat_transfer_coefficient * area_convection
@@ -341,7 +341,7 @@ function insulation_radiant_temperature(
         )
     else
         ins_calc1 =
-            ((3 * volume * bs) / ((((3 * ssqg)^0.5)^3) * geometric_divisor)) *
+            ((3 * volume * bs) / ((sqrt(3 * ssqg)^3) * geometric_divisor)) *
             (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
         ins_calc2 =
             coeffs.sky * T.sky + coeffs.bush * T.bush + coeffs.vegetation * T.vegetation + coeffs.ground * T.ground
@@ -349,7 +349,7 @@ function insulation_radiant_temperature(
             heat_transfer_coefficient * area_convection * T.air - conductance_coefficient * compressed_insulation_temperature + conductance_coefficient * T.substrate -
             insulation_evaporation_heat_flow + solar_flow
         ins_calc4 =
-            (3 * volume * bs * uncompressed_conductance) / ((((3 * ssqg)^0.5)^3) * geometric_divisor) +
+            (3 * volume * bs * uncompressed_conductance) / ((sqrt(3 * ssqg)^3) * geometric_divisor) +
             (coeffs.sky + coeffs.bush + coeffs.vegetation + coeffs.ground) +
             heat_transfer_coefficient * area_convection
         calculated_insulation_temperature = u"K"((ins_calc1 + ins_calc2 + ins_calc3) / ins_calc4)

--- a/src/insulated/mean_skin_temperature.jl
+++ b/src/insulated/mean_skin_temperature.jl
@@ -82,7 +82,7 @@ function mean_skin_temperature(
     else
         skin_temperature_calc1 =
             core_temperature - ((environment_flow * r_flesh^2) / (4 * conductivities.flesh * volume)) -
-            ((environment_flow * r_flesh^2.0) / (2 * conductivities.fat * volume)) * log(r_skin / r_flesh)
+            ((environment_flow * r_flesh^2) / (2 * conductivities.fat * volume)) * log(r_skin / r_flesh)
         skin_temperature_calc2 =
             (
                 ((environment_flow * r_flesh^2) / (2 * insulation.conductivity_compressed * volume)) *
@@ -113,7 +113,7 @@ function mean_skin_temperature(
     if conduction_fraction < 1
         skin_temperature_calc1 =
             core_temperature - (((environment_flow + skin_evaporation_flow) * r_flesh^2) / (6 * conductivities.flesh * volume)) -
-            (((environment_flow + skin_evaporation_flow) * r_flesh^3.0) / (3 * conductivities.fat * volume)) *
+            (((environment_flow + skin_evaporation_flow) * r_flesh^3) / (3 * conductivities.fat * volume)) *
             ((r_skin - r_flesh) / (r_skin * r_flesh))
         skin_temperature_calc2 =
             ((environment_flow * r_flesh^3) / (3 * conductances.total * volume * r_skin)) +
@@ -171,20 +171,20 @@ function mean_skin_temperature(
     if conduction_fraction < 1
         skin_temperature_calc1 =
             core_temperature - (((environment_flow + skin_evaporation_flow) * ssqg) / (2 * conductivities.flesh * volume)) -
-            (((environment_flow + skin_evaporation_flow) * (((3 * ssqg)^0.5)^3)) / (3 * conductivities.fat * volume)) *
+            (((environment_flow + skin_evaporation_flow) * (sqrt(3 * ssqg)^3)) / (3 * conductivities.fat * volume)) *
             ((bs - bg) / (bs * bg))
         skin_temperature_calc2 =
-            ((environment_flow * (((3 * ssqg)^0.5)^3)) / (3 * conductances.total * volume * bs)) +
+            ((environment_flow * (sqrt(3 * ssqg)^3)) / (3 * conductances.total * volume * bs)) +
             ((compressed_insulation_temperature * conductances.compressed) / conductances.total) +
             ((calculated_insulation_temperature * conductances.uncompressed) / conductances.total)
     else
         skin_temperature_calc1 =
             core_temperature - ((environment_flow * ssqg) / (2 * conductivities.flesh * volume)) -
-            ((environment_flow * (((3 * ssqg)^0.5)^3)) / (3 * conductivities.fat * volume)) *
+            ((environment_flow * (sqrt(3 * ssqg)^3)) / (3 * conductivities.fat * volume)) *
             ((bs - bg) / (bs * bg))
         skin_temperature_calc2 =
             (
-                ((environment_flow * (((3 * ssqg)^0.5)^3)) / (3 * insulation.conductivity_compressed * volume)) *
+                ((environment_flow * (sqrt(3 * ssqg)^3)) / (3 * insulation.conductivity_compressed * volume)) *
                 ((bl_compressed - bs) / (bl_compressed * bs))
             ) + compressed_insulation_temperature
     end

--- a/src/insulated/net_metabolic_heat.jl
+++ b/src/insulated/net_metabolic_heat.jl
@@ -67,7 +67,7 @@ function net_metabolic_heat(
 
     net_metabolic_heat_production = (core_temperature - skin_temperature) / (
             (ssqg / (2 * conductivities.flesh * volume)) +
-            (((((3 * ssqg)^0.5)^3) / (3 * conductivities.fat * volume)) * ((bs - bg) / (bg * bs)))
+            (((sqrt(3 * ssqg)^3) / (3 * conductivities.fat * volume)) * ((bs - bg) / (bg * bs)))
         )
     return net_metabolic_heat_production
 end

--- a/src/insulated/radiant_temperature.jl
+++ b/src/insulated/radiant_temperature.jl
@@ -286,18 +286,21 @@ function radiant_temperature(
     numerator_divisor =
         (bs / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance - insulation_temperature * uncompressed_conductance) / br
 
+    # The two branches must return the same Quantity type. Without the
+    # uconvert and the matching unit on the `else` divisor, the if/else
+    # joined to a Union and Enzyme lost the ability to differentiate through.
     radiative_divisor = if longwave_depth_fraction < 1
         compressed_conductance + ((conductivities.insulation * bl) / (bl - br)) * (1 - conduction_fraction)
     else
-        1.0
+        oneunit(compressed_conductance)
     end
 
     radiant_temperature = if longwave_depth_fraction < 1
-        numerator_divisor / radiative_divisor +
-        (compressed_insulation_temperature * compressed_conductance) / radiative_divisor +
-        (insulation_temperature * ((conductivities.insulation * bl) / (bl - br) * (1 - conduction_fraction))) / radiative_divisor
+        u"K"(numerator_divisor / radiative_divisor +
+             (compressed_insulation_temperature * compressed_conductance) / radiative_divisor +
+             (insulation_temperature * ((conductivities.insulation * bl) / (bl - br) * (1 - conduction_fraction))) / radiative_divisor)
     else
-        insulation_temperature
+        u"K"(insulation_temperature)
     end
     conductances = ConductanceCoeffs(total_conductance, compressed_conductance, uncompressed_conductance)
     divisors = DivisorCoeffs(geometric_divisor, evaporative_divisor, numerator_divisor, radiative_divisor)

--- a/src/insulated/utils.jl
+++ b/src/insulated/utils.jl
@@ -414,5 +414,5 @@ function _assemble_multisided_output(o, e, core_temperature, metabolic_heat_flow
         molar_fluxes_in,
         molar_fluxes_out,
     )
-    return (; thermoregulation, morphology, energy_flows, mass_flows)
+    return ThermoregulationOutput(thermoregulation, morphology, energy_flows, mass_flows)
 end

--- a/src/nlp_interface.jl
+++ b/src/nlp_interface.jl
@@ -477,7 +477,7 @@ function nlp_assemble_output(p::WeightedMeanNLPPacked, organism::Organism, envir
         insulation_temperature             = insulation_temperature,
         lung_temperature,
         insulation_depth,
-        aspect_ratio                       = sol_aspect_ratio,
+        axis_ratio_b                       = sol_aspect_ratio,
         pant,
         skin_wetness,
         flesh_conductivity                 = k_flesh,
@@ -547,7 +547,7 @@ function nlp_assemble_output(p::WeightedMeanNLPPacked, organism::Organism, envir
         molar_fluxes_out = respiration_result.molar_fluxes_out,
     )
 
-    return (; thermoregulation, morphology, energy_flows, mass_flows)
+    return ThermoregulationOutput(thermoregulation, morphology, energy_flows, mass_flows)
 end
 
 # ---------------------------------------------------------------------------
@@ -637,7 +637,7 @@ function nlp_assemble_output(p::MultiSidedNLPPacked, organism::Organism, environ
         insulation_temperature,
         lung_temperature,
         insulation_depth,
-        aspect_ratio                       = sol_aspect_ratio,
+        axis_ratio_b                       = sol_aspect_ratio,
         pant,
         skin_wetness,
         flesh_conductivity                 = k_flesh,
@@ -736,5 +736,5 @@ function nlp_assemble_output(p::MultiSidedNLPPacked, organism::Organism, environ
         molar_fluxes_out = respiration_result.molar_fluxes_out,
     )
 
-    return (; thermoregulation, morphology, energy_flows, mass_flows)
+    return ThermoregulationOutput(thermoregulation, morphology, energy_flows, mass_flows)
 end

--- a/src/solve_metabolic_rate.jl
+++ b/src/solve_metabolic_rate.jl
@@ -2,6 +2,24 @@
 # Finds the metabolic_heat_flow that closes the heat budget at a fixed core temperature.
 
 """
+    ThermoregulationOutput(thermoregulation, morphology, energy_flows, mass_flows)
+
+Canonical return type for `solve_metabolic_rate` and the IPOPT/NLP path.
+Each field is a NamedTuple:
+
+- `thermoregulation`: temperature states and effector values at the solution.
+- `morphology`: body surface areas and geometric measures.
+- `energy_flows`: heat fluxes (solar, longwave, generated, evaporation, etc.).
+- `mass_flows`: respiration and sweat mass flows.
+"""
+struct ThermoregulationOutput{T, M, E, F}
+    thermoregulation::T
+    morphology::M
+    energy_flows::E
+    mass_flows::F
+end
+
+"""
     SolveMetabolicRateOptions
 
 Options controlling the endotherm metabolic rate solver.

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -68,7 +68,7 @@ function _outer_insulation_thickness(ci::CompositeInsulation)
 end
 
 characteristic_dimension(::VolumeCubeRoot, body) =
-    body.geometry.volume^(1/3) + _outer_insulation_thickness(body.insulation)
+    cbrt(body.geometry.volume) + _outer_insulation_thickness(body.insulation)
 
 characteristic_dimension(sd::ScaledDimension, body) =
     sd.factor * getproperty(body.geometry.length, sd.dimension)

--- a/test/heat_balance.jl
+++ b/test/heat_balance.jl
@@ -242,13 +242,13 @@ e = (; environment_pars, environment_vars)
 # heat_balance on a MultiSided organism raises MethodError — use solve_temperature instead
 @test_throws MethodError heat_balance(u"K"(30.0u"°C"), organism, e)
 
-# solve_temperature returns a rich NamedTuple with whole-organism and per-side results
+# solve_temperature returns a rich ThermoregulationOutput with whole-organism and per-side results
 result = solve_temperature(organism, e)
-@test result isa NamedTuple
-@test haskey(result, :thermoregulation)
-@test haskey(result, :energy_flows)
-@test haskey(result.energy_flows, :dorsal)
-@test haskey(result.energy_flows, :ventral)
-@test haskey(result.thermoregulation, :dorsal)
-@test haskey(result.thermoregulation, :ventral)
+@test result isa ThermoregulationOutput
+@test :thermoregulation in propertynames(result)
+@test :energy_flows in propertynames(result)
+@test :dorsal in propertynames(result.energy_flows)
+@test :ventral in propertynames(result.energy_flows)
+@test :dorsal in propertynames(result.thermoregulation)
+@test :ventral in propertynames(result.thermoregulation)
 @test u"K"(0.0u"°C") < result.thermoregulation.core_temperature < u"K"(80.0u"°C")


### PR DESCRIPTION
A grab bag of small fixes for package updates and autodiff 


- insulation_thermal_conductivity: canonicalise inputs to SI before arithmetic so downstream FreeUnits ordering doesn't depend on call-site units; cast r_air, r_fibre, a_fibre, effective_conductivity to canonical units to keep the if/else joins single-typed (the Union-typed joins tripped Enzyme's reverse pass).
- radiant_temperature: oneunit() and u"K" casts on if/else arms so both branches return the same Quantity type.
- compressed_radiant_temperature, insulation_radiant_temperature, mean_skin_temperature, net_metabolic_heat: replace ((3*ssqg)^0.5)^3 with sqrt(3*ssqg)^3 (correct semantics, AD-friendly), drop spurious ^2.0 / ^3.0 in favour of integer powers.
- traits.jl: cbrt() instead of ^(1/3) for AD support.
- biophysics.jl: drop debug println in nusselt_free.
- ThermoregulationOutput: add explicit struct (defined in solve_metabolic_rate.jl, exported, returned by nlp_assemble_output and _assemble_multisided_output) so the IPOPT/NLP and rule-based paths share a canonical return type.
- nlp_assemble_output: rename aspect_ratio -> axis_ratio_b for consistency with the rule-based thermoregulation output.