### PR TITLE
Improve type stability, AD safety, and smoothing coverage

### DIFF
--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -93,7 +93,13 @@ export ConductanceCoeffs,
     Emissivities,
     Absorptivities,
     InsulationProperties,
-    GeometryVariables
+    GeometryVariables,
+    BodySide,
+    Dorsal,
+    Ventral,
+    Fluid,
+    Air,
+    Water
 
 export CharacteristicDimFormula, VolumeCubeRoot, ScaledDimension, characteristic_dimension
 

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -170,6 +170,26 @@ function radiation_out(
     return (; longwave_flow_out, longwave_to_sky_flow, longwave_to_substrate_flow)
 end
 
+# --- Fluid-property dispatch ---------------------------------------------
+# Pick (cp_fluid, density, conductivity, dynamic_viscosity) for the ambient
+# fluid. Splitting these into methods on `Air()` / `Water()` lets the compiler
+# erase the unused branch entirely.
+@inline _fluid_properties(::Air, ::Any, dry_air_out) = (
+    1.0057E+3u"J/K/kg",
+    dry_air_out.density,
+    dry_air_out.thermal_conductivity,
+    dry_air_out.dynamic_viscosity,
+)
+@inline function _fluid_properties(::Water, air_temperature, ::Any)
+    w = water_properties(air_temperature)
+    return (w.specific_heat, w.density, w.thermal_conductivity, w.dynamic_viscosity)
+end
+
+# Schmidt number is meaningful for air but not for water; in water we return
+# 1 to keep the downstream Sherwood/Nusselt expressions well-typed.
+@inline _schmidt_number(::Air,   μ, ρ, D)  = μ / (ρ * D)
+@inline _schmidt_number(::Water, ::Any, ::Any, ::Any) = 1.0
+
 """
     convection(; body, area, air_temperature, surface_temperature, wind_speed, atmospheric_pressure, fluid, gas_fractions, convection_enhancement)
 
@@ -182,7 +202,7 @@ Calculate combined free and forced convective heat transfer for an organism.
 - `surface_temperature`: Surface temperature
 - `wind_speed`: Wind speed
 - `atmospheric_pressure`: Atmospheric pressure
-- `fluid`: Fluid type (0 = air, 1 = water)
+- `fluid::Fluid`: Fluid singleton (`Air()` or `Water()`)
 - `gas_fractions::GasFractions`: Gas fractions for air properties (default: `GasFractions()`)
 - `convection_enhancement`: Enhancement factor for forced convection (default: 1.0)
 
@@ -209,28 +229,14 @@ function convection(;
     characteristic_dim = characteristic_dimension(characteristic_dimension_formula, body)
     dry_air_out = dry_air_properties(air_temperature, atmospheric_pressure; gas_fractions)
     vapour_diffusivity = dry_air_out.vapour_diffusivity
-    # checking to see if the fluid is water, not air
-    if fluid == 1
-        water_prop_out = water_properties(air_temperature)
-        cp_fluid = water_prop_out.specific_heat
-        fluid_density = water_prop_out.density
-        fluid_conductivity = water_prop_out.thermal_conductivity
-        dynamic_viscosity = water_prop_out.dynamic_viscosity
-    else
-        cp_fluid = 1.0057E+3u"J/K/kg"
-        fluid_density = dry_air_out.density
-        fluid_conductivity = dry_air_out.thermal_conductivity
-        dynamic_viscosity = dry_air_out.dynamic_viscosity
-    end
+    # Dispatch on the fluid singleton — both branches are concrete-typed and
+    # the unused one is dead-code-eliminated.
+    cp_fluid, fluid_density, fluid_conductivity, dynamic_viscosity =
+        _fluid_properties(fluid, air_temperature, dry_air_out)
 
     # free convection
     prandtl_number = cp_fluid * dynamic_viscosity / u"J/s/K/m"(fluid_conductivity)
-    if fluid == 1
-        #  water; no meaning
-        schmidt_number = 1
-    else
-        schmidt_number = dynamic_viscosity / (fluid_density * vapour_diffusivity)
-    end
+    schmidt_number = _schmidt_number(fluid, dynamic_viscosity, fluid_density, vapour_diffusivity)
     # |ΔT| in the Grashof number. HardBound uses exact `abs`; SmoothBound replaces
     # it with sqrt(ΔT² + (ε·scale)²) so Enzyme reverse-mode does not see a kink at
     # ΔT = 0 (which produced NaN gradients when the optimiser landed there).
@@ -238,6 +244,28 @@ function convection(;
     # the meaningful signal at any sensible ε.
     ΔT = surface_temperature - air_temperature
     temperature_difference = safe_abs(smoothing, ΔT; scale=1.0u"K")
+    # AD-safety floor on temperature_difference. The Grashof number is linear
+    # in `temperature_difference`, and `nusselt_free` then raises it to a
+    # fractional power (`grashof^(1/4)` for Sphere/Ellipsoid; a piecewise
+    # `rayleigh^p` with non-integer `p` for Cylinder). At grashof = 0 the
+    # derivative of `^p` (0 < p < 1) is `+Inf`, and `Inf · 0` — the zero seed
+    # from any AD input that does NOT actually affect ΔT — evaluates to NaN,
+    # poisoning the entire Jacobian (both forward and reverse).
+    #
+    # This bites in practice because IPOPT's initial guess sets
+    # `insulation_temperature_init = air_temperature` exactly, so the first
+    # Jacobian evaluation lands at ΔT = 0. Under HardBound, `safe_abs(ΔT)`
+    # is the bare `abs` and returns 0; under SmoothBound it already returns
+    # `ε·scale`, but we floor uniformly so both smoothing strategies are
+    # equally safe and the floor is independent of `ε`.
+    #
+    # The 1e-6 K floor is well below the smallest meaningful temperature
+    # difference (millikelvin level even in tight thermoregulation work),
+    # so the primal stays bit-identical away from ΔT = 0.
+    # TODO: if a third call site needs this pattern (`^p` of a quantity that
+    # can hit zero) consider hoisting into a `safe_pow_floor` helper alongside
+    # `safe_abs` in `smoothing.jl`.
+    temperature_difference = max(temperature_difference, 1.0e-6u"K")
     grashof_number = ((fluid_density^2) * thermal_expansion_coefficient * Unitful.gn * (characteristic_dim^3) * temperature_difference) / (dynamic_viscosity^2)
     reynolds_number = fluid_density * wind_speed * characteristic_dim /dynamic_viscosity
     free_nusselt_number = nusselt_free(body.shape, grashof_number, prandtl_number)

--- a/src/environment.jl
+++ b/src/environment.jl
@@ -13,7 +13,7 @@ Base.@kwdef struct EnvironmentalPars{AG,EG,ES,EL,FL,G,CE,CD} <: AbstractEnvironm
     ground_emissivity::EG = Param(1.0, bounds=(0.0, 1.0))
     sky_emissivity::ES = Param(1.0, bounds=(0.0, 1.0))
     elevation::EL = Param(0.0, units=u"m")
-    fluid::FL = Param(0)
+    fluid::FL = Air()
     gas_fractions::G = GasFractions()
     convection_enhancement::CE = Param(1.0)
     conduction_depth::CD = Param(2.5u"cm", bounds=(0.0, 200.0))

--- a/src/heat_balance.jl
+++ b/src/heat_balance.jl
@@ -19,7 +19,8 @@ Returns a NamedTuple:
 - `longwave_gain_out` — full longwave-in output
 - `longwave_loss_out` — full longwave-out output
 """
-function _radiative_convective_flows(surface_temperature, o::Organism, environment_pars, environment_vars)
+function _radiative_convective_flows(surface_temperature, o::Organism, environment_pars, environment_vars;
+                                      smoothing::SmoothingStrategy=HardBound())
     external_conduction = conduction_pars_external(o)
     rad_pars = radiation_pars(o)
     conv_pars = convection_pars(o)
@@ -62,6 +63,7 @@ function _radiative_convective_flows(surface_temperature, o::Organism, environme
         gas_fractions=environment_pars.gas_fractions,
         convection_enhancement=environment_pars.convection_enhancement,
         characteristic_dimension_formula=conv_pars.characteristic_dimension_formula,
+        smoothing,
     )
     convection_heat_flow = convection_out.convection_flow
 
@@ -89,18 +91,19 @@ Dispatches first on `evaluation_strategy(organism)`:
 - `organism::Organism`: Organism with body geometry and traits
 - `e`: Environment containing `environment_pars` and `environment_vars`
 """
-heat_balance(T, organism::Organism, e) =
-    heat_balance(T, evaluation_strategy(organism), evaporation_pars(organism), organism, e)
+heat_balance(T, organism::Organism, e; smoothing::SmoothingStrategy=HardBound()) =
+    heat_balance(T, evaluation_strategy(organism), evaporation_pars(organism), organism, e; smoothing)
 
 # SingleBody: drop the strategy, dispatch on evaporation type
-heat_balance(T, ::SingleBody, ep, o::Organism, e) = heat_balance(T, ep, o, e)
+heat_balance(T, ::SingleBody, ep, o::Organism, e; smoothing::SmoothingStrategy=HardBound()) =
+    heat_balance(T, ep, o, e; smoothing)
 
 # Animal/ectotherm SingleBody: dispatch on insulation type
-heat_balance(T, ::AnimalEvaporationParameters, o::Organism, e) =
-    heat_balance(T, insulation(body(o)), o, e)
+heat_balance(T, ::AnimalEvaporationParameters, o::Organism, e; smoothing::SmoothingStrategy=HardBound()) =
+    heat_balance(T, insulation(body(o)), o, e; smoothing)
 
 
-function heat_balance(core_temperature, ::Naked, o::Organism, e)
+function heat_balance(core_temperature, ::Naked, o::Organism, e; smoothing::SmoothingStrategy=HardBound())
     environment_pars = stripparams(e.environment_pars)
     environment_vars = e.environment_vars
     internal_conduction = conduction_pars_internal(o)
@@ -123,6 +126,7 @@ function heat_balance(core_temperature, ::Naked, o::Organism, e)
         clamp(core_temperature, u"K"(1.0u"°C"), u"K"(50.0u"°C")),
         environment_vars.air_temperature;
         gas_fractions=environment_pars.gas_fractions,
+        smoothing,
     )
     respiration_heat_flow = respiration_out.respiration_heat_flow
     oxygen_flow = u"ml/hr"(Joules_to_O2(metabolic_heat_flow))
@@ -138,7 +142,7 @@ function heat_balance(core_temperature, ::Naked, o::Organism, e)
     )
 
     # radiative + convective flows
-    flows = _radiative_convective_flows(surface_temperature, o, environment_pars, environment_vars)
+    flows = _radiative_convective_flows(surface_temperature, o, environment_pars, environment_vars; smoothing)
     (; solar_flow, longwave_flow_in, longwave_flow_out, convection_heat_flow,
        convection_out, convection_area, conduction_area,
        solar_out, longwave_gain_out, longwave_loss_out) = flows
@@ -231,7 +235,8 @@ Dark respiration heat is included in `metabolic_heat_flow` via the metabolic mod
 (e.g. `PlantDarkRespiration`); `respiration_heat_flow` in `energy_balance` is `0.0 W`
 (leaves have no pulmonary respiratory heat loss).
 """
-function heat_balance(core_temperature, evap_pars::LeafEvaporationParameters, o::Organism, e)
+function heat_balance(core_temperature, evap_pars::LeafEvaporationParameters, o::Organism, e;
+                       smoothing::SmoothingStrategy=HardBound())
     environment_pars = stripparams(e.environment_pars)
     environment_vars = e.environment_vars
     internal_conduction = conduction_pars_internal(o)
@@ -251,7 +256,7 @@ function heat_balance(core_temperature, evap_pars::LeafEvaporationParameters, o:
     )
 
     # radiative + convective flows
-    flows = _radiative_convective_flows(surface_temperature, o, environment_pars, environment_vars)
+    flows = _radiative_convective_flows(surface_temperature, o, environment_pars, environment_vars; smoothing)
     (; solar_flow, longwave_flow_in, longwave_flow_out,
        convection_heat_flow, convection_out, convection_area,
        solar_out, longwave_gain_out, longwave_loss_out) = flows
@@ -388,9 +393,9 @@ function heat_balance(
 
     # Recompute temperature-dependent insulation conductivity at current temperatures.
     (; insulation_conductivity, effective_conductivity) = _insulation_conductivity(
-        insulation, insulation_pars, side, insulation_temperature, skin_temperature, longwave_depth_fraction, σ)
+        insulation, insulation_pars, side, insulation_temperature, skin_temperature, longwave_depth_fraction, σ; smoothing)
     conductivities = ThermalConductivities(k_flesh, fat_conductivity, insulation_conductivity)
-    insulation_updated = setproperties(insulation; conductivity_compressed = effective_conductivity)
+    insulation_updated = setproperties(insulation, (; conductivity_compressed = effective_conductivity))
 
     # -------------------------------------------------------------------------
     # Convection at insulation surface
@@ -440,6 +445,7 @@ function heat_balance(
         conduction_fraction,
         evaporation_flow = skin_evaporation_heat_flow,
         substrate_temperature,
+        smoothing,
     )
     radiant_temp = radiant_temp_result.radiant_temperature
     compressed_insulation_temperature = radiant_temp_result.compressed_insulation_temperature
@@ -484,6 +490,7 @@ function heat_balance(
         conductivities,
         core_temperature,
         skin_temperature,
+        smoothing,
     )
 
     # -------------------------------------------------------------------------
@@ -503,6 +510,7 @@ function heat_balance(
         core_temperature,
         calculated_insulation_temperature = insulation_temperature,
         compressed_insulation_temperature,
+        smoothing,
     )
     skin_temperature_from_heat_balance = mean_skin_temp_result.mean_skin_temperature
 
@@ -510,7 +518,7 @@ function heat_balance(
     # Respiration with pant override
     # -------------------------------------------------------------------------
     lung_temperature = (core_temperature + skin_temperature) / 2
-    resp_pars_effective = setproperties(resp_pars; pant)
+    resp_pars_effective = setproperties(resp_pars, (; pant))
     resp_out = respiration(
         MetabolicRates(; metabolic = metabolic_heat_flow, sum = metabolic_heat_flow, minimum = minimum_metabolic_heat),
         resp_pars_effective,
@@ -520,6 +528,7 @@ function heat_balance(
         air_temperature;
         gas_fractions,
         O2conversion = Kleiber1961(),
+        smoothing,
     )
     respiration_heat_flow = uconvert(u"W", resp_out.respiration_heat_flow)
 

--- a/src/insulated/compressed_radiant_temperature.jl
+++ b/src/insulated/compressed_radiant_temperature.jl
@@ -104,11 +104,7 @@ function compressed_radiant_temperature(
     substrate_temperature,
 )
     volume = flesh_volume(body)
-    insulation_depth = if side == :dorsal
-        insulation_pars.dorsal.depth
-    else
-        insulation_pars.ventral.depth
-    end
+    insulation_depth = _side_value(insulation_pars, side).depth
 
     a_semi_major = body.geometry.length.a_semi_major
     b_semi_minor = body.geometry.length.b_semi_minor

--- a/src/insulated/insulation.jl
+++ b/src/insulated/insulation.jl
@@ -25,14 +25,18 @@ NamedTuple with:
 - Kowalski, K. A. (1983). *A model of heat transfer through mammalian fur*. PhD Thesis,
   University of Wisconsin.
 """
-function insulation_thermal_conductivity(fibre::FibreProperties, air_conductivity; depth=nothing)
+insulation_thermal_conductivity(fibre::FibreProperties, air_conductivity; smoothing::SmoothingStrategy=HardBound()) =
+    insulation_thermal_conductivity(fibre, air_conductivity, fibre.depth; smoothing)
+
+function insulation_thermal_conductivity(fibre::FibreProperties, air_conductivity, depth;
+                                         smoothing::SmoothingStrategy=HardBound())
     # Canonicalise inputs to SI before any arithmetic. Otherwise
     # `density * (fibre.length / insulation_depth)` carries the literal
     # unit ratio of whichever inputs were used (e.g. mm/m gives a non-
     # canonical FreeUnits) and every downstream type becomes call-site-
     # dependent. Caller-side unit choices then make the whole function
     # type-unstable from a downstream view.
-    insulation_depth = uconvert(u"m", isnothing(depth) ? fibre.depth : depth)
+    insulation_depth = uconvert(u"m", depth)
     fibre_length     = uconvert(u"m", fibre.length)
     fibre_diameter   = uconvert(u"m", fibre.diameter)
     density          = uconvert(u"m^-2", fibre.density)
@@ -47,14 +51,15 @@ function insulation_thermal_conductivity(fibre::FibreProperties, air_conductivit
     fibre_spacing = l_unit - fibre_diameter
 
     # Resolve crowded-fibre case (no space between fibres) by re-deriving
-    # density from a hard-packed lattice. After this block both branches
-    # below produce the same unit types — the explicit uconvert casts
-    # restore the canonical FreeUnits ordering after the arithmetic, so
-    # the locals don't end up Union-typed across the join (dimension
-    # matches but FreeUnits ordering can differ, which is invisible to
-    # JET but trips Enzyme's reverse pass).
+    # density from a hard-packed lattice. The reassignment must preserve
+    # the element type (e.g. `Dual` under AD) — naively setting
+    # `l_unit = fibre_diameter` would collapse the branch back to
+    # `Float64` even when the open case carried a `Dual`, producing a
+    # `Union` join in inference and ~kB / call of boxed allocations.
+    # `+ zero(l_unit)` is a no-op value-wise but promotes to the wider
+    # type.
     if fibre_spacing < 0.0u"m"
-        l_unit = fibre_diameter
+        l_unit = fibre_diameter + zero(l_unit)
         effective_density = uconvert(u"m^-2", 1.0 / l_unit^2)
         density = uconvert(u"m^-2", (effective_density * insulation_depth) / fibre_length)
         fibre_spacing = l_unit - fibre_diameter
@@ -90,8 +95,8 @@ function insulation_thermal_conductivity(fibre::FibreProperties, air_conductivit
     # different FreeUnits orderings (computed `(ky+kx)/2`, fibre.conductivity,
     # air_conductivity) and produce a Union return type.
     effective_conductivity = u"W/m/K"((ky + kx) / 2.0)
-    effective_conductivity = clamp(effective_conductivity,
-        u"W/m/K"(air_conductivity), u"W/m/K"(fibre.conductivity))
+    effective_conductivity = safe_clamp(smoothing, effective_conductivity,
+        u"W/m/K"(air_conductivity), u"W/m/K"(fibre.conductivity); scale=u"W/m/K"(air_conductivity))
 
     # Absorption and optical parameters
     absorption_coefficient = (0.67 / π) * u"m^-2"(effective_density) * u"m"(fibre_diameter)
@@ -132,27 +137,30 @@ function insulation_properties(insulation::InsulationParameters, insulation_temp
     # Weighted average fibre properties
     avg_fibres = interpolate(dorsal, ventral, ventral_fraction)
 
-    # Adjusted ventral values (accounting for partial insulation coverage)
-    ventral_adj = interpolate(dorsal, ventral, min(ventral_fraction * 2.0, 1.0))
+    # Adjusted ventral values (accounting for partial insulation coverage).
+    # `ventral_fraction` is dimensionless in [0, 1]; the kink is at `2v = 1`.
+    # `scale = 0.01` (vs the default `oneunit(...) = 1.0`) tightens the
+    # SmoothBound transition to a fractional width of 0.01·ε around the kink —
+    # well inside the [0, 1] range without overlapping the physical extremes.
+    ventral_adj = interpolate(dorsal, ventral, safe_min(smoothing, ventral_fraction * 2.0, 1.0; scale=0.01))
 
     fibres = BodyRegionValues(avg_fibres, dorsal, ventral_adj)
 
     # Bare-skin (zero density / depth / length) makes `insulation_thermal_conductivity`
-    # divide by zero, so we cannot use a `mask * value` blend — IEEE keeps NaN
-    # through `0 * NaN`. The inner function is now canonical-typed across both
-    # arms (W/m/K, m^-1, NoUnits), so the if/else does not Union-typed-return
-    # and remains AD-friendly. `smoothing` stays in the signature for API
-    # consistency with other call sites.
-    conductivity_compressed = 0.0u"W/m/K"
-    if insulation_test <= 0.0u"m"
-        conductivities = BodyRegionValues(0.0u"W/m/K", 0.0u"W/m/K", 0.0u"W/m/K")
-        absorption_coefficients = BodyRegionValues(0.0u"m^-1", 0.0u"m^-1", 0.0u"m^-1")
-        optical_thickness = BodyRegionValues(0.0, 0.0, 0.0)
-    else
-        avg  = insulation_thermal_conductivity(fibres.average, air_conductivity)
-        dors = insulation_thermal_conductivity(fibres.dorsal,  air_conductivity)
-        vent = insulation_thermal_conductivity(fibres.ventral, air_conductivity)
-        vent_compressed = insulation_thermal_conductivity(fibres.ventral, air_conductivity; depth=depth_compressed)
+    # divide by zero, so we can't use a `mask * value` blend — IEEE keeps NaN through
+    # `0 * NaN`. We need a Union-free return type under AD (Dual through
+    # `air_conductivity` and `fibres`), so both branches must produce the same
+    # concrete component types. The bare-skin branch can't use literal `0.0u"..."`
+    # because the canonical-W/m/K branch's Unitful FreeUnits ordering differs from
+    # a literal's. We anchor the types by calling `insulation_thermal_conductivity`
+    # once on `fibres.average` (always defined), then `zero(...)` of its component
+    # fields gives the bare-skin values. `zero(NaN) == 0.0`, so the NaN-producing
+    # call on truly-bare-skin inputs is harmless: we consume the type, not the value.
+    if insulation_test > zero(insulation_test)
+        avg  = insulation_thermal_conductivity(fibres.average, air_conductivity; smoothing)
+        dors = insulation_thermal_conductivity(fibres.dorsal,  air_conductivity; smoothing)
+        vent = insulation_thermal_conductivity(fibres.ventral, air_conductivity; smoothing)
+        vent_compressed = insulation_thermal_conductivity(fibres.ventral, air_conductivity, depth_compressed; smoothing)
         conductivities = BodyRegionValues(
             avg.effective_conductivity, dors.effective_conductivity, vent.effective_conductivity,
         )
@@ -163,6 +171,16 @@ function insulation_properties(insulation::InsulationParameters, insulation_temp
             avg.optical_thickness_factor, dors.optical_thickness_factor, vent.optical_thickness_factor,
         )
         conductivity_compressed = vent_compressed.effective_conductivity
+    else
+        # Single anchor call for type-only consumption.
+        anchor = insulation_thermal_conductivity(fibres.average, air_conductivity; smoothing)
+        zk = zero(anchor.effective_conductivity)
+        za = zero(anchor.absorption_coefficient)
+        zo = zero(anchor.optical_thickness_factor)
+        conductivities          = BodyRegionValues(zk, zk, zk)
+        absorption_coefficients = BodyRegionValues(za, za, za)
+        optical_thickness       = BodyRegionValues(zo, zo, zo)
+        conductivity_compressed = zk
     end
 
     return InsulationProperties(

--- a/src/insulated/insulation_radiant_temperature.jl
+++ b/src/insulated/insulation_radiant_temperature.jl
@@ -106,17 +106,10 @@ function insulation_radiant_temperature(
     r_insulation = insulation_radius(body)
     length = body.geometry.length.length_skin
 
-    if side == :dorsal
-        r_radiation =
-            r_skin +
-            insulation_pars.longwave_depth_fraction *
-            insulation_pars.dorsal.depth
-    else
-        r_radiation =
-            r_skin +
-            insulation_pars.longwave_depth_fraction *
-            insulation_pars.ventral.depth
-    end
+    r_radiation =
+        r_skin +
+        insulation_pars.longwave_depth_fraction *
+        _side_value(insulation_pars, side).depth
 
     if longwave_depth_fraction < 1
         ins_calc1 =
@@ -197,17 +190,10 @@ function insulation_radiant_temperature(
     r_skin = skin_radius(body)
     r_insulation = insulation_radius(body)
 
-    if side == :dorsal
-        r_radiation =
-            r_skin +
-            insulation_pars.longwave_depth_fraction *
-            insulation_pars.dorsal.depth
-    else
-        r_radiation =
-            r_skin +
-            insulation_pars.longwave_depth_fraction *
-            insulation_pars.ventral.depth
-    end
+    r_radiation =
+        r_skin +
+        insulation_pars.longwave_depth_fraction *
+        _side_value(insulation_pars, side).depth
 
     if longwave_depth_fraction < 1
         ins_calc1 = ((4 * π * r_skin) / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance)
@@ -296,11 +282,7 @@ function insulation_radiant_temperature(
     b_semi_minor_flesh = b_semi_minor - fat
     c_semi_minor_flesh = c_semi_minor - fat
 
-    if side == :dorsal
-        insulation_depth = insulation_pars.dorsal.depth
-    else
-        insulation_depth = insulation_pars.ventral.depth
-    end
+    insulation_depth = _side_value(insulation_pars, side).depth
 
     a_square = min(a_semi_major_flesh^2, a_semi_major^2)
     b_square = min(b_semi_minor_flesh^2, b_semi_minor^2)

--- a/src/insulated/mean_skin_temperature.jl
+++ b/src/insulated/mean_skin_temperature.jl
@@ -36,6 +36,7 @@ function mean_skin_temperature(;
     core_temperature,
     calculated_insulation_temperature,
     compressed_insulation_temperature,
+    smoothing::SmoothingStrategy=HardBound(),
 )
     mean_skin_temperature(
         shape(body),
@@ -49,7 +50,8 @@ function mean_skin_temperature(;
         skin_evaporation_flow,
         core_temperature,
         calculated_insulation_temperature,
-        compressed_insulation_temperature,
+        compressed_insulation_temperature;
+        smoothing,
     )
 end
 function mean_skin_temperature(
@@ -64,7 +66,8 @@ function mean_skin_temperature(
     skin_evaporation_flow,
     core_temperature,
     calculated_insulation_temperature,
-    compressed_insulation_temperature,
+    compressed_insulation_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     volume = flesh_volume(body)
     r_skin = skin_radius(body)
@@ -104,7 +107,8 @@ function mean_skin_temperature(
     skin_evaporation_flow,
     core_temperature,
     calculated_insulation_temperature,
-    compressed_insulation_temperature,
+    compressed_insulation_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     volume = flesh_volume(body)
     r_skin = skin_radius(body)
@@ -145,7 +149,8 @@ function mean_skin_temperature(
     skin_evaporation_flow,
     core_temperature,
     calculated_insulation_temperature,
-    compressed_insulation_temperature,
+    compressed_insulation_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     volume = flesh_volume(body)
     a_semi_major = body.geometry.length.a_semi_major_skin
@@ -156,9 +161,9 @@ function mean_skin_temperature(
     b_semi_minor_flesh = b_semi_minor - fat
     c_semi_minor_flesh = c_semi_minor - fat
 
-    a_square = min(a_semi_major_flesh^2, a_semi_major^2)
-    b_square = min(b_semi_minor_flesh^2, b_semi_minor^2)
-    c_square = min(c_semi_minor_flesh^2, c_semi_minor^2)
+    a_square = safe_min(smoothing, a_semi_major_flesh^2, a_semi_major^2; scale=oneunit(a_semi_major^2))
+    b_square = safe_min(smoothing, b_semi_minor_flesh^2, b_semi_minor^2; scale=oneunit(b_semi_minor^2))
+    c_square = safe_min(smoothing, c_semi_minor_flesh^2, c_semi_minor^2; scale=oneunit(c_semi_minor^2))
 
     ssqg =
         (a_square * b_square * c_square) /
@@ -166,7 +171,7 @@ function mean_skin_temperature(
 
     bs = b_semi_minor
     bl_compressed = b_semi_minor + insulation_pars.depth_compressed
-    bg = min(b_semi_minor, b_semi_minor_flesh)
+    bg = safe_min(smoothing, b_semi_minor, b_semi_minor_flesh; scale=oneunit(b_semi_minor))
 
     if conduction_fraction < 1
         skin_temperature_calc1 =

--- a/src/insulated/net_metabolic_heat.jl
+++ b/src/insulated/net_metabolic_heat.jl
@@ -15,11 +15,13 @@ the metabolic heat production needed.
 # Returns
 - `net_metabolic_heat_production`: Net metabolic heat generation (W)
 """
-function net_metabolic_heat(; body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature)
-    net_metabolic_heat(shape(body), body, conductivities, core_temperature, skin_temperature)
+function net_metabolic_heat(; body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature,
+                              smoothing::SmoothingStrategy=HardBound())
+    net_metabolic_heat(shape(body), body, conductivities, core_temperature, skin_temperature; smoothing)
 end
 function net_metabolic_heat(
-    shape::Union{Cylinder,Plate}, body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature
+    shape::Union{Cylinder,Plate}, body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     volume = flesh_volume(body)
     r_skin = skin_radius(body)
@@ -31,7 +33,8 @@ function net_metabolic_heat(
     return net_metabolic_heat_production
 end
 function net_metabolic_heat(
-    shape::Sphere, body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature
+    shape::Sphere, body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     volume = flesh_volume(body)
     r_skin = skin_radius(body)
@@ -43,7 +46,8 @@ function net_metabolic_heat(
     return net_metabolic_heat_production
 end
 function net_metabolic_heat(
-    shape::Ellipsoid, body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature
+    shape::Ellipsoid, body::AbstractBody, conductivities::ThermalConductivities, core_temperature, skin_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     volume = flesh_volume(body)
     a_semi_major = body.geometry.length.a_semi_major_skin
@@ -54,16 +58,16 @@ function net_metabolic_heat(
     b_semi_minor_flesh = b_semi_minor - fat
     c_semi_minor_flesh = c_semi_minor - fat
 
-    a_square = min(a_semi_major_flesh^2, a_semi_major^2)
-    b_square = min(b_semi_minor_flesh^2, b_semi_minor^2)
-    c_square = min(c_semi_minor_flesh^2, c_semi_minor^2)
+    a_square = safe_min(smoothing, a_semi_major_flesh^2, a_semi_major^2; scale=oneunit(a_semi_major^2))
+    b_square = safe_min(smoothing, b_semi_minor_flesh^2, b_semi_minor^2; scale=oneunit(b_semi_minor^2))
+    c_square = safe_min(smoothing, c_semi_minor_flesh^2, c_semi_minor^2; scale=oneunit(c_semi_minor^2))
 
     ssqg =
         (a_square * b_square * c_square) /
         (a_square * b_square + a_square * c_square + b_square * c_square)
 
     bs = b_semi_minor
-    bg = min(b_semi_minor, b_semi_minor_flesh)
+    bg = safe_min(smoothing, b_semi_minor, b_semi_minor_flesh; scale=oneunit(b_semi_minor))
 
     net_metabolic_heat_production = (core_temperature - skin_temperature) / (
             (ssqg / (2 * conductivities.flesh * volume)) +

--- a/src/insulated/radiant_temperature.jl
+++ b/src/insulated/radiant_temperature.jl
@@ -38,6 +38,7 @@ function radiant_temperature(;
     conduction_fraction,
     evaporation_flow,
     substrate_temperature,
+    smoothing::SmoothingStrategy=HardBound(),
 )
     radiant_temperature(
         shape(body),
@@ -51,7 +52,8 @@ function radiant_temperature(;
         longwave_depth_fraction,
         conduction_fraction,
         evaporation_flow,
-        substrate_temperature,
+        substrate_temperature;
+        smoothing,
     )
 end
 function radiant_temperature(
@@ -66,7 +68,8 @@ function radiant_temperature(
     longwave_depth_fraction,
     conduction_fraction,
     evaporation_flow,
-    substrate_temperature,
+    substrate_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     (; core_temperature, skin_temperature, insulation_temperature) = org_temps
 
@@ -74,7 +77,7 @@ function radiant_temperature(
     r_skin = skin_radius(body)
     r_flesh = flesh_radius(body)
     r_insulation = insulation_radius(body)
-    insulation_depth = getproperty(insulation.fibres, side).depth
+    insulation_depth = _side_value(insulation.fibres, side).depth
     r_radiation = r_skin + insulation_pars.longwave_depth_fraction * insulation_depth
     compressed_conductivity = insulation.conductivity_compressed
     r_compressed = r_skin + insulation_pars.depth_compressed
@@ -82,11 +85,12 @@ function radiant_temperature(
 
     compression_fraction =
         (conduction_fraction * 2 * π * compressed_conductivity * length) / log(r_compressed / r_skin)
-    compressed_insulation_temperature = if conduction_fraction > 0
-        (compression_fraction * skin_temperature + conductance_coefficient * substrate_temperature) / (conductance_coefficient + compression_fraction)
-    else
-        0.0u"K"
-    end
+    compressed_insulation_temperature = safe_gated_ratio(
+        conduction_fraction,
+        compression_fraction * skin_temperature + conductance_coefficient * substrate_temperature,
+        conductance_coefficient + compression_fraction,
+        zero(skin_temperature),
+    )
 
     total_conductance =
         (compressed_conductivity / log(r_compressed / r_skin)) * conduction_fraction +
@@ -142,7 +146,8 @@ function radiant_temperature(
     longwave_depth_fraction,
     conduction_fraction,
     evaporation_flow,
-    substrate_temperature,
+    substrate_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     (; core_temperature, skin_temperature, insulation_temperature) = org_temps
 
@@ -150,7 +155,7 @@ function radiant_temperature(
     r_skin = skin_radius(body)
     r_flesh = flesh_radius(body)
     r_insulation = insulation_radius(body)
-    insulation_depth = getproperty(insulation.fibres, side).depth
+    insulation_depth = _side_value(insulation.fibres, side).depth
     r_radiation = r_skin + insulation_pars.longwave_depth_fraction * insulation_depth
     compressed_conductivity = insulation.conductivity_compressed
     r_compressed = r_skin + insulation_pars.depth_compressed
@@ -159,11 +164,12 @@ function radiant_temperature(
         (conduction_fraction * 4 * π * compressed_conductivity * r_compressed * r_skin) /
         (r_compressed - r_skin)
 
-    compressed_insulation_temperature = if conduction_fraction > 0
-        (compression_fraction * skin_temperature + conductance_coefficient * substrate_temperature) / (conductance_coefficient + compression_fraction)
-    else
-        0.0u"K"
-    end
+    compressed_insulation_temperature = safe_gated_ratio(
+        conduction_fraction,
+        compression_fraction * skin_temperature + conductance_coefficient * substrate_temperature,
+        conductance_coefficient + compression_fraction,
+        zero(skin_temperature),
+    )
 
     total_conductance =
         ((compressed_conductivity * r_compressed) / (r_compressed - r_skin)) * conduction_fraction +
@@ -228,7 +234,8 @@ function radiant_temperature(
     longwave_depth_fraction,
     conduction_fraction,
     evaporation_flow,
-    substrate_temperature,
+    substrate_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     (; core_temperature, skin_temperature, insulation_temperature) = org_temps
 
@@ -242,19 +249,23 @@ function radiant_temperature(
     b_semi_minor_flesh = b_semi_minor - fat
     c_semi_minor_flesh = c_semi_minor - fat
 
-    insulation_depth = getproperty(insulation.fibres, side).depth
+    insulation_depth = _side_value(insulation.fibres, side).depth
     compressed_conductivity = insulation.conductivity_compressed
     bl_compressed = b_semi_minor + insulation_pars.depth_compressed
 
-    a_square = min(a_semi_major_flesh^2, a_semi_major^2)
-    b_square = min(b_semi_minor_flesh^2, b_semi_minor^2)
-    c_square = min(c_semi_minor_flesh^2, c_semi_minor^2)
+    # `min(flesh², skin²)` is a guard for the unphysical fat<0 case. The kink
+    # at the crossover is what makes reverse-mode AD bail. Smooth the min so
+    # the derivative is continuous through the boundary; in the physical case
+    # (flesh ≤ skin) `safe_min` returns the flesh value to numerical precision.
+    a_square = safe_min(smoothing, a_semi_major_flesh^2, a_semi_major^2; scale=oneunit(a_semi_major^2))
+    b_square = safe_min(smoothing, b_semi_minor_flesh^2, b_semi_minor^2; scale=oneunit(b_semi_minor^2))
+    c_square = safe_min(smoothing, c_semi_minor_flesh^2, c_semi_minor^2; scale=oneunit(c_semi_minor^2))
 
     ssqg =
         (a_square * b_square * c_square) /
         (a_square * b_square + a_square * c_square + b_square * c_square)
 
-    bg = min(b_semi_minor, b_semi_minor_flesh)
+    bg = safe_min(smoothing, b_semi_minor, b_semi_minor_flesh; scale=oneunit(b_semi_minor))
     bs = b_semi_minor
     bl = b_semi_minor + insulation_depth
     br = bs + longwave_depth_fraction * insulation_depth
@@ -263,11 +274,12 @@ function radiant_temperature(
         (conduction_fraction * 3 * compressed_conductivity * volume * bl_compressed * bs) /
         ((sqrt(3 * ssqg))^3 * (bl_compressed - bs))
 
-    compressed_insulation_temperature = if conduction_fraction > 0.0
-        (compression_fraction * skin_temperature + conductance_coefficient * substrate_temperature) / (conductance_coefficient + compression_fraction)
-    else
-        0.0u"K"
-    end
+    compressed_insulation_temperature = safe_gated_ratio(
+        conduction_fraction,
+        compression_fraction * skin_temperature + conductance_coefficient * substrate_temperature,
+        conductance_coefficient + compression_fraction,
+        zero(skin_temperature),
+    )
 
     total_conductance =
         ((compressed_conductivity * bl_compressed) / (bl_compressed - bs)) * conduction_fraction +
@@ -286,22 +298,20 @@ function radiant_temperature(
     numerator_divisor =
         (bs / geometric_divisor) * (core_temperature * total_conductance - evaporative_divisor - compressed_insulation_temperature * compressed_conductance - insulation_temperature * uncompressed_conductance) / br
 
-    # The two branches must return the same Quantity type. Without the
-    # uconvert and the matching unit on the `else` divisor, the if/else
-    # joined to a Union and Enzyme lost the ability to differentiate through.
-    radiative_divisor = if longwave_depth_fraction < 1
-        compressed_conductance + ((conductivities.insulation * bl) / (bl - br)) * (1 - conduction_fraction)
-    else
+    # `longwave_depth_fraction == 1` makes `bl - br = 0` (singular). The
+    # `lwdf` is a fixed parameter (default ≈ 0.4), not an IPOPT effector, so
+    # the branch is data-stable across a solve. Keep the conditional but make
+    # both arms return the same Quantity types to keep inference Union-free —
+    # the wrong arm is dead-code-eliminated for a given parameter setting.
+    radiative_divisor = longwave_depth_fraction < 1 ?
+        compressed_conductance + ((conductivities.insulation * bl) / (bl - br)) * (1 - conduction_fraction) :
         oneunit(compressed_conductance)
-    end
 
-    radiant_temperature = if longwave_depth_fraction < 1
+    radiant_temperature = longwave_depth_fraction < 1 ?
         u"K"(numerator_divisor / radiative_divisor +
              (compressed_insulation_temperature * compressed_conductance) / radiative_divisor +
-             (insulation_temperature * ((conductivities.insulation * bl) / (bl - br) * (1 - conduction_fraction))) / radiative_divisor)
-    else
+             (insulation_temperature * ((conductivities.insulation * bl) / (bl - br) * (1 - conduction_fraction))) / radiative_divisor) :
         u"K"(insulation_temperature)
-    end
     conductances = ConductanceCoeffs(total_conductance, compressed_conductance, uncompressed_conductance)
     divisors = DivisorCoeffs(geometric_divisor, evaporative_divisor, numerator_divisor, radiative_divisor)
     return (; radiant_temperature, compressed_insulation_temperature, conductances, divisors)

--- a/src/insulated/skin_and_insulation_temperature.jl
+++ b/src/insulated/skin_and_insulation_temperature.jl
@@ -23,17 +23,30 @@ function _insulation_evaporation(conv, atmos, area_convection, insulation_temper
     return mask * flow
 end
 
-function _insulation_conductivity(insulation, insulation_pars, side, insulation_temperature, skin_temperature, longwave_depth_fraction, σ)
+function _insulation_conductivity(insulation, insulation_pars, side, insulation_temperature, skin_temperature, longwave_depth_fraction, σ;
+                                  smoothing::SmoothingStrategy=HardBound())
     insulation_temp_mean = insulation_temperature * 0.7 + skin_temperature * 0.3
     air_k = dry_air_properties(insulation_temp_mean).thermal_conductivity
-    side_depth = getproperty(insulation.fibres, side).depth
-    side_fibres = setproperties(getproperty(insulation_pars, side); depth = side_depth)
-    effective_conductivity = insulation_thermal_conductivity(side_fibres, air_k).effective_conductivity
-    absorption_coefficient = getproperty(insulation.absorption_coefficients, side)
+    side_depth  = _side_value(insulation.fibres, side).depth
+    side_fibres = _side_value(insulation_pars, side)
+    effective_conductivity = insulation_thermal_conductivity(side_fibres, air_k, side_depth; smoothing).effective_conductivity
+    absorption_coefficient = _side_value(insulation.absorption_coefficients, side)
     approx_radiant_temperature = skin_temperature * (1 - longwave_depth_fraction) + insulation_temperature * longwave_depth_fraction
     radiative_conductivity = (16 * σ * approx_radiant_temperature^3) / (3 * absorption_coefficient)
     return (; insulation_conductivity = effective_conductivity + radiative_conductivity, effective_conductivity)
 end
+
+# Type-stable selector for the dorsal/ventral field of a `BodyRegionValues`
+# / `DorsalVentral` / `InsulationParameters` etc. Dispatching on the
+# `BodySide` singleton lets the compiler pick the right field at compile
+# time and erase the wrong branch entirely.
+@inline _side_value(x, ::Dorsal)  = x.dorsal
+@inline _side_value(x, ::Ventral) = x.ventral
+
+# Update only the matching side's conductivity field — dispatch picks the
+# right setproperties call at compile time.
+@inline _set_side_conductivity(c, ::Dorsal,  v) = setproperties(c, (; dorsal  = v))
+@inline _set_side_conductivity(c, ::Ventral, v) = setproperties(c, (; ventral = v))
 
 function _radiation_coefficients(area, view_factors, ϵ, σ, radiant_temperature, env_temps)
     T = env_temps
@@ -82,6 +95,7 @@ function solve_temperatures(;
     temperature_tolerance,
     skin_temperature,
     insulation_temperature,
+    smoothing::SmoothingStrategy=HardBound(),
 )
     insulation_test = u"m"(insulation.insulation_test)
     success = true
@@ -96,7 +110,8 @@ function solve_temperatures(;
             traits,
             temperature_tolerance,
             skin_temperature,
-            insulation_temperature,
+            insulation_temperature;
+            smoothing,
         )
     else
         return solve_without_insulation!(
@@ -106,13 +121,15 @@ function solve_temperatures(;
             traits,
             temperature_tolerance,
             skin_temperature,
-            insulation_temperature,
+            insulation_temperature;
+            smoothing,
         )
     end
 end
 
 function solve_without_insulation!(
-    body::AbstractBody, geometry_vars::GeometryVariables, environment_vars::NamedTuple, traits::NamedTuple, temperature_tolerance, skin_temperature, insulation_temperature
+    body::AbstractBody, geometry_vars::GeometryVariables, environment_vars::NamedTuple, traits::NamedTuple, temperature_tolerance, skin_temperature, insulation_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     (;
         temperature,
@@ -155,6 +172,7 @@ function solve_without_insulation!(
                 fluid,
                 gas_fractions,
                 convection_enhancement,
+                smoothing,
             )
             heat_transfer_coefficient = conv.heat_transfer_coefficient.combined
             evap_pars_local = AnimalEvaporationParameters(;
@@ -267,7 +285,8 @@ function solve_with_insulation!(
     traits::NamedTuple,
     temperature_tolerance,
     skin_temperature,
-    insulation_temperature,
+    insulation_temperature;
+    smoothing::SmoothingStrategy=HardBound(),
 )
     (; side, conductance_coefficient, ventral_fraction, conduction_fraction, longwave_depth_fraction) = geometry_vars
     (;
@@ -326,6 +345,7 @@ function solve_with_insulation!(
                 fluid,
                 gas_fractions,
                 convection_enhancement,
+                smoothing,
             )
             heat_transfer_coefficient = conv.heat_transfer_coefficient.combined
             evap_pars_skin = AnimalEvaporationParameters(;
@@ -346,16 +366,12 @@ function solve_with_insulation!(
             # second from insulation
             insulation_evaporation_heat_flow = _insulation_evaporation(
                 conv, atmos_skin, area_convection, insulation_temperature, air_temperature,
-                insulation_wetness, insulation_test; gas_fractions)
+                insulation_wetness, insulation_test; gas_fractions, smoothing)
             # Recompute insulation thermal properties for current temperatures
             (; insulation_conductivity, effective_conductivity) = _insulation_conductivity(
                 insulation, insulation_pars, side, insulation_temperature, skin_temperature,
-                longwave_depth_fraction, σ)
-            side_conductivities = if side == :dorsal
-                setproperties(insulation.conductivities; dorsal=effective_conductivity)
-            else
-                setproperties(insulation.conductivities; ventral=effective_conductivity)
-            end
+                longwave_depth_fraction, σ; smoothing)
+            side_conductivities = _set_side_conductivity(insulation.conductivities, side, effective_conductivity)
             insulation = setproperties(insulation;
                 conductivity_compressed=effective_conductivity,
                 conductivities=side_conductivities,
@@ -374,6 +390,7 @@ function solve_with_insulation!(
                 conduction_fraction,
                 evaporation_flow=skin_evaporation_flow,
                 substrate_temperature,
+                smoothing,
             )
             calculated_radiant_temperature = radiant_temp_result.radiant_temperature
             compressed_insulation_temperature = radiant_temp_result.compressed_insulation_temperature
@@ -455,6 +472,7 @@ function solve_with_insulation!(
                 core_temperature,
                 calculated_insulation_temperature=insulation_temperature_calc,
                 compressed_insulation_temperature,
+                smoothing,
             )
 
             # Build flows (net_metabolic updated on success)
@@ -479,7 +497,7 @@ function solve_with_insulation!(
             if Δinsulation_temperature < tolerance
                 # Next check skin_temperature convergence
                 if Δskin_temperature < tolerance
-                    net_metabolic = net_metabolic_heat(; body, conductivities, core_temperature, skin_temperature)
+                    net_metabolic = net_metabolic_heat(; body, conductivities, core_temperature, skin_temperature, smoothing)
                     flows = setproperties(flows; net_metabolic)
                     return (;
                         insulation_temperature,
@@ -496,7 +514,7 @@ function solve_with_insulation!(
                         skin_temperature = skin_temperature_calc1
                         continue
                     else
-                        net_metabolic = net_metabolic_heat(; body, conductivities, core_temperature, skin_temperature)
+                        net_metabolic = net_metabolic_heat(; body, conductivities, core_temperature, skin_temperature, smoothing)
                         flows = setproperties(flows; net_metabolic)
                         return (;
                             insulation_temperature,

--- a/src/insulated/types.jl
+++ b/src/insulated/types.jl
@@ -1,4 +1,50 @@
 """
+    BodySide
+
+Abstract supertype for body-side selectors. `Dorsal()` and `Ventral()` are
+singleton subtypes — they parameterise `GeometryVariables{S,...}` so the
+compiler can specialise on side and eliminate the wrong-branch code.
+"""
+abstract type BodySide end
+
+"""
+    Dorsal() <: BodySide
+
+Singleton indicating the dorsal (upper / back) body side.
+"""
+struct Dorsal <: BodySide end
+
+"""
+    Ventral() <: BodySide
+
+Singleton indicating the ventral (lower / belly) body side.
+"""
+struct Ventral <: BodySide end
+
+"""
+    Fluid
+
+Abstract supertype for the ambient fluid. `Air()` and `Water()` are singleton
+subtypes — dispatching on them lets the convection code specialise on the
+fluid kind at compile time so the wrong branch is eliminated entirely.
+"""
+abstract type Fluid end
+
+"""
+    Air() <: Fluid
+
+Singleton indicating air as the ambient fluid (dry-air properties path).
+"""
+struct Air <: Fluid end
+
+"""
+    Water() <: Fluid
+
+Singleton indicating water as the ambient fluid (water-properties path).
+"""
+struct Water <: Fluid end
+
+"""
     ConductanceCoeffs{T1,T2,T3}
 
 Thermal conductance coefficients through insulation layers.
@@ -389,13 +435,13 @@ end
 Geometric and thermal parameters for heat exchange calculations on a body side.
 
 # Fields
-- `side` — Body side (`:dorsal` or `:ventral`)
+- `side::BodySide` — Body side (`Dorsal()` or `Ventral()`)
 - `conductance_coefficient` — Thermal conductance to substrate (W/K), conduction_flow = conductance_coefficient × ΔT
 - `ventral_fraction` — Fraction of body surface that is ventral (0-1)
 - `conduction_fraction` — Fraction of surface area in contact with substrate (0-1)
 - `longwave_depth_fraction` — Fraction of insulation depth for longwave radiation exchange (0-1)
 """
-Base.@kwdef struct GeometryVariables{S,SC,VF,CF,LDF}
+Base.@kwdef struct GeometryVariables{S<:BodySide,SC,VF,CF,LDF}
     side::S
     conductance_coefficient::SC
     ventral_fraction::VF

--- a/src/insulated/utils.jl
+++ b/src/insulated/utils.jl
@@ -35,10 +35,19 @@ Linearly interpolate between two `FibreProperties` objects.
 Returns `a * (1 - t) + b * t` for each field.
 """
 function interpolate(a::FibreProperties, b::FibreProperties, t::Number)
-    interpolated = map(getproperties(a), getproperties(b)) do a, b
-        interpolate(a, b, t)
-    end
-    return setproperties(a; interpolated...)
+    # Explicit field-by-field construction. The `map(getproperties(a),
+    # getproperties(b))` + kwarg-splatted `setproperties` indirection used to
+    # produce a heap allocation per call when this function was reached
+    # through Enzyme.Forward — Enzyme could not erase the intermediate
+    # NamedTuple. Going direct lets the compiler keep the result on the stack.
+    FibreProperties(
+        interpolate(a.diameter,     b.diameter,     t),
+        interpolate(a.length,       b.length,       t),
+        interpolate(a.density,      b.density,      t),
+        interpolate(a.depth,        b.depth,        t),
+        interpolate(a.reflectance,  b.reflectance,  t),
+        interpolate(a.conductivity, b.conductivity, t),
+    )
 end
 interpolate(a::Number, b::Number, t::Number) = a * (1 - t) + b * t
 
@@ -58,7 +67,8 @@ Returns a NamedTuple with:
 - `fibres` — insulation fibre properties (for geometry_avg construction)
 - `evap_pars` — possibly adjusted evaporation parameters (bare_skin_fraction reset if no insulation)
 """
-function _pack_sides(o::Organism, e, core_temperature, skin_temperature, insulation_temperature)
+function _pack_sides(o::Organism, e, core_temperature, skin_temperature, insulation_temperature;
+                     smoothing::SmoothingStrategy=HardBound())
     environment_pars = stripparams(e.environment_pars)
     environment_vars = e.environment_vars
     opts = options(o)
@@ -69,7 +79,7 @@ function _pack_sides(o::Organism, e, core_temperature, skin_temperature, insulat
     evap_pars = evaporation_pars(o)
 
     avg_insulation_temp = insulation_temperature * 0.7 + skin_temperature * 0.3
-    insulation = insulation_properties(ins_pars, avg_insulation_temp, rad_pars.ventral_fraction)
+    insulation = insulation_properties(ins_pars, avg_insulation_temp, rad_pars.ventral_fraction; smoothing)
     fibres = insulation.fibres
     if insulation.insulation_test <= 0.0u"m" && evap_pars.bare_skin_fraction < 1.0
         evap_pars = AnimalEvaporationParameters(;
@@ -113,9 +123,9 @@ function _pack_sides(o::Organism, e, core_temperature, skin_temperature, insulat
     side_traits        = Vector{NamedTuple}(undef, 2)
     temperature_error_tolerance = opts.temperature_error_tolerance
 
-    for (side_idx, side) in enumerate((:dorsal, :ventral))
+    for (side_idx, side) in enumerate((Dorsal(), Ventral()))
         side_sky_factor, side_ground_factor, side_bush_factor, side_vegetation_factor = if solar_flow > 0.0u"W"
-            if side == :dorsal
+            if side isa Dorsal
                 solar_flow = 2.0 * solar_direct_flow + ((solar_sky_flow / sky_factor_ref) * sky_factor_ref * 2.0)
                 (sky_factor_ref * 2.0, 0.0, 0.0, vegetation_factor_ref * 2.0)
             else
@@ -126,20 +136,20 @@ function _pack_sides(o::Organism, e, core_temperature, skin_temperature, insulat
             end
         else
             solar_flow = 0.0u"W"
-            if side == :dorsal
+            if side isa Dorsal
                 (sky_factor_ref * 2.0, 0.0, 0.0, vegetation_factor_ref * 2.0)
             else
                 (0.0, ground_factor_ref * 2.0, bush_factor_ref * 2.0, 0.0)
             end
         end
 
-        ϵ_body = side == :dorsal ? rad_pars.body_emissivity_dorsal : rad_pars.body_emissivity_ventral
+        ϵ_body = side isa Dorsal ? rad_pars.body_emissivity_dorsal : rad_pars.body_emissivity_ventral
 
-        side_fibres = getproperty(fibres, side)
+        side_fibres = _side_value(fibres, side)
         insulation_layer = FibrousLayer(side_fibres.depth, side_fibres.diameter, side_fibres.density)
         geometry_pars = Body(o.body.shape, CompositeInsulation(insulation_layer, fat))
 
-        conductance_coefficient = if side == :ventral
+        conductance_coefficient = if side isa Ventral
             body_total_area = BiophysicalGeometry.total_area(geometry_pars)
             area_cond = body_total_area * external_conduction.conduction_fraction * 2
             (area_cond * environment_vars.substrate_conductivity) / environment_pars.conduction_depth
@@ -182,7 +192,7 @@ function _pack_sides(o::Organism, e, core_temperature, skin_temperature, insulat
         )
 
         insulation = insulation_properties(
-            ins_pars, insulation_temperature * 0.7 + skin_temperature * 0.3, rad_pars.ventral_fraction
+            ins_pars, insulation_temperature * 0.7 + skin_temperature * 0.3, rad_pars.ventral_fraction; smoothing
         )
         temps_out[side_idx] = solve_temperatures(;
             body=geometry_pars,
@@ -194,6 +204,7 @@ function _pack_sides(o::Organism, e, core_temperature, skin_temperature, insulat
             temperature_tolerance=opts.temperature_error_tolerance,
             skin_temperature,
             insulation_temperature,
+            smoothing,
         )
 
         side_bodies[side_idx]        = geometry_pars
@@ -229,7 +240,8 @@ or `nothing` when respiration is disabled.
 `energy_flows` includes `metabolic_heat_flow` and per-side `dorsal`/`ventral` sub-fields.
 `thermoregulation` includes per-side `dorsal`/`ventral` sub-fields alongside existing flat scalars.
 """
-function _assemble_multisided_output(o, e, core_temperature, metabolic_heat_flow, respiration_out, packed)
+function _assemble_multisided_output(o, e, core_temperature, metabolic_heat_flow, respiration_out, packed;
+                                     smoothing::SmoothingStrategy=HardBound())
     environment_vars = e.environment_vars
     ins_pars = insulation_pars(o)
     external_conduction = conduction_pars_external(o)
@@ -253,7 +265,7 @@ function _assemble_multisided_output(o, e, core_temperature, metabolic_heat_flow
     skin_temp_avg = (temps_out[1].skin_temperature + temps_out[2].skin_temperature) * 0.5
     ins_temp_avg  = (temps_out[1].insulation_temperature + temps_out[2].insulation_temperature) * 0.5
     insulation_for_test = insulation_properties(
-        ins_pars, ins_temp_avg * 0.7 + skin_temp_avg * 0.3, rad_pars.ventral_fraction
+        ins_pars, ins_temp_avg * 0.7 + skin_temp_avg * 0.3, rad_pars.ventral_fraction; smoothing
     )
     has_insulation = insulation_for_test.insulation_test > 0.0u"m"
 
@@ -310,7 +322,7 @@ function _assemble_multisided_output(o, e, core_temperature, metabolic_heat_flow
     insulation_temperature = temps_out[1].insulation_temperature * dmult + temps_out[2].insulation_temperature * vmult
     insulation_depth       = ins_pars.dorsal.depth * dmult + ins_pars.ventral.depth * vmult
     insulation_final = insulation_properties(
-        ins_pars, insulation_temperature * 0.7 + skin_temperature * 0.3, rad_pars.ventral_fraction
+        ins_pars, insulation_temperature * 0.7 + skin_temperature * 0.3, rad_pars.ventral_fraction; smoothing
     )
     insulation_conductivity_effective  = insulation_final.conductivities.average
     insulation_conductivity_compressed = insulation_final.conductivity_compressed

--- a/src/nlp_interface.jl
+++ b/src/nlp_interface.jl
@@ -109,10 +109,12 @@ function nlp_pack(::WeightedMeanNLP, organism::Organism, environment, initial_sk
                                      solar_conds, reference_silhouette_area, reference_conduction_area)
 
     if solar_result.solar_flow > 0.0u"W"
-        dorsal_solar_flow  = 2.0 * solar_result.solar_direct_flow + solar_result.solar_sky_flow * 2.0
-        ventral_solar_flow = (solar_result.solar_substrate_flow /
-                              (1.0 - sky_view_factor - vegetation_view_factor)) *
-                             (1.0 - 2.0 * ext_cond.conduction_fraction)
+        dorsal_solar_flow  = uconvert(u"W",
+            2.0 * solar_result.solar_direct_flow + solar_result.solar_sky_flow * 2.0)
+        ventral_solar_flow = uconvert(u"W",
+            (solar_result.solar_substrate_flow /
+             (1.0 - sky_view_factor - vegetation_view_factor)) *
+            (1.0 - 2.0 * ext_cond.conduction_fraction))
     else
         dorsal_solar_flow  = 0.0u"W"
         ventral_solar_flow = 0.0u"W"
@@ -163,7 +165,7 @@ function nlp_pack(::WeightedMeanNLP, organism::Organism, environment, initial_sk
         eye_fraction       = evap_pars.eye_fraction,
     )
     geometry_vars = GeometryVariables(;
-        side                    = :dorsal,
+        side                    = Dorsal(),
         conductance_coefficient = mean_conduction_coeff,
         ventral_fraction,
         conduction_fraction     = ext_cond.conduction_fraction,
@@ -182,7 +184,9 @@ function nlp_pack(::WeightedMeanNLP, organism::Organism, environment, initial_sk
         sky_view_factor,
         ground_view_factor,
         ext_cond,
-        rad_pars,
+        body_emissivity_dorsal  = rad_pars.body_emissivity_dorsal,
+        body_emissivity_ventral = rad_pars.body_emissivity_ventral,
+        solar_orientation       = rad_pars.solar_orientation,
         int_cond,
         resp_pars,
         heat_balance_env,
@@ -225,7 +229,7 @@ function nlp_pack(::MultiSidedNLP, organism::Organism, environment, initial_skin
 
     # Call _pack_sides at the setpoint temperature to get initial guesses and
     # per-side packed structures (environment, traits, geometry_vars, bodies)
-    packed = _pack_sides(organism, environment, metab_pars.core_temperature, initial_skin_temperature, initial_insulation_temperature)
+    packed = _pack_sides(organism, environment, metab_pars.core_temperature, initial_skin_temperature, initial_insulation_temperature; smoothing)
 
     p = (;
         ins_pars,
@@ -234,7 +238,9 @@ function nlp_pack(::MultiSidedNLP, organism::Organism, environment, initial_skin
         fat,
         ext_cond,
         int_cond,
-        rad_pars,
+        body_emissivity_dorsal  = rad_pars.body_emissivity_dorsal,
+        body_emissivity_ventral = rad_pars.body_emissivity_ventral,
+        solar_orientation       = rad_pars.solar_orientation,
         resp_pars,
         ventral_fraction       = rad_pars.ventral_fraction,
         substrate_conductivity = env_vars.substrate_conductivity,
@@ -467,8 +473,8 @@ function nlp_assemble_output(p::WeightedMeanNLPPacked, organism::Organism, envir
     σ                    = Unitful.uconvert(u"W/m^2/K^4", Unitful.σ)
     sol_total_area       = BiophysicalGeometry.total_area(sol_body)
     sol_ventral_rad_area = sol_total_area * (1 - pp.ext_cond.conduction_fraction)
-    dorsal_lw_out        = _side_lw_out(pp.sky_view_factor,    pp.rad_pars.body_emissivity_dorsal,  sol_total_area,       insulation_temperature, σ)
-    ventral_lw_out       = _side_lw_out(pp.ground_view_factor, pp.rad_pars.body_emissivity_ventral, sol_ventral_rad_area, insulation_temperature, σ)
+    dorsal_lw_out        = _side_lw_out(pp.sky_view_factor,    pp.body_emissivity_dorsal,  sol_total_area,       insulation_temperature, σ)
+    ventral_lw_out       = _side_lw_out(pp.ground_view_factor, pp.body_emissivity_ventral, sol_ventral_rad_area, insulation_temperature, σ)
     longwave_flow_out    = dorsal_lw_out * pp.dorsal_weight + ventral_lw_out * pp.ventral_weight
     longwave_flow_in     = longwave_flow_out - hf.radiation_heat_flow
 
@@ -508,7 +514,7 @@ function nlp_assemble_output(p::WeightedMeanNLPPacked, organism::Organism, envir
     area_skin        = skin_area(sol_body)
     area_evaporation = evaporation_area(sol_body)
     area_convection  = sol_total_area * (1 - pp.ext_cond.conduction_fraction)
-    area_silhouette  = silhouette_area(sol_body, pp.rad_pars.solar_orientation)
+    area_silhouette  = silhouette_area(sol_body, pp.solar_orientation)
 
     morphology = (;
         total_area         = sol_total_area,
@@ -614,8 +620,8 @@ function nlp_assemble_output(p::MultiSidedNLPPacked, organism::Organism, environ
     σ                    = Unitful.uconvert(u"W/m^2/K^4", Unitful.σ)
     sol_total_area       = BiophysicalGeometry.total_area(sol_body_d)
     sol_ventral_rad_area = sol_total_area * (1 - pp.ext_cond.conduction_fraction)
-    dorsal_lw_out        = _side_lw_out(pp.sky_factor_ref,    pp.rad_pars.body_emissivity_dorsal,  sol_total_area,       dorsal_insulation_temperature, σ)
-    ventral_lw_out       = _side_lw_out(pp.ground_factor_ref, pp.rad_pars.body_emissivity_ventral, sol_ventral_rad_area, ventral_insulation_temperature, σ)
+    dorsal_lw_out        = _side_lw_out(pp.sky_factor_ref,    pp.body_emissivity_dorsal,  sol_total_area,       dorsal_insulation_temperature, σ)
+    ventral_lw_out       = _side_lw_out(pp.ground_factor_ref, pp.body_emissivity_ventral, sol_ventral_rad_area, ventral_insulation_temperature, σ)
     dorsal_lw_in         = dorsal_lw_out  - hf_d.radiation_heat_flow
     ventral_lw_in        = ventral_lw_out - hf_v.radiation_heat_flow
     longwave_flow_out    = dorsal_lw_out * dmult + ventral_lw_out * vmult
@@ -668,7 +674,7 @@ function nlp_assemble_output(p::MultiSidedNLPPacked, organism::Organism, environ
     area_evaporation = evaporation_area(sol_body_d)
     area_convection  = sol_total_area * (1 - pp.ext_cond.conduction_fraction)
     area_skin        = skin_area(sol_body_d)
-    area_silhouette  = silhouette_area(sol_body_d, pp.rad_pars.solar_orientation)
+    area_silhouette  = silhouette_area(sol_body_d, pp.solar_orientation)
 
     morphology = (;
         total_area         = sol_total_area,

--- a/src/respiration.jl
+++ b/src/respiration.jl
@@ -28,6 +28,7 @@ function respiration(
     air_temperature;
     gas_fractions::GasFractions=GasFractions(),
     O2conversion::OxygenJoulesConversion=Typical(),
+    smoothing::SmoothingStrategy=HardBound(),
 )
     (; metabolic, sum, minimum) = rates
     metabolic_heat_flow, heat_flow_sum, minimum_heat_flow = metabolic, sum, minimum
@@ -43,7 +44,7 @@ function respiration(
         fO2 = 1 - (fN2 + fCO2)
     end
 
-    resp_gen = max(metabolic_heat_flow, minimum_heat_flow)
+    resp_gen = safe_max(smoothing, metabolic_heat_flow, minimum_heat_flow; scale=oneunit(metabolic_heat_flow))
 
     # joules of energy dissipated per m3 O2 consumed at standard temperature and pressure (enthalpy of combustion)
     oxygen_flow_standard = u"m^3/s"(Joules_to_O2(O2conversion, resp_gen, respiratory_quotient))
@@ -64,8 +65,8 @@ function respiration(
     # computing the vapor pressure at saturation for the subsequent calculation of
     # actual moles of water based on actual relative humidity
     saturation_vapour_pressure = vapour_pressure(air_temperature)
-    water_in = air_in * (saturation_vapour_pressure * relative_humidity) / 
-        max(atmospheric_pressure - saturation_vapour_pressure * relative_humidity, 1e-6u"Pa")
+    water_in = air_in * (saturation_vapour_pressure * relative_humidity) /
+        safe_max(smoothing, atmospheric_pressure - saturation_vapour_pressure * relative_humidity, 1e-6u"Pa"; scale=1.0u"Pa")
     # moles at exit
     oxygen_out = oxygen_in - oxygen_consumed # remove consumed oxygen from the total
     nitrogen_out = nitrogen_in
@@ -95,7 +96,7 @@ function respiration(
     # 2.22e-03*
     # (edwards & haines 1978. j. comp. physiol. 128: 177-184 in welch 1980)
     # for a 0.01 kg animal, the max. rate would be 1.67 x 10^-6 g/s
-    respiration_mass_flow = min(respiration_mass_flow, (2.22E-03 * ustrip(u"kg", mass) * 15)u"g/s")
+    respiration_mass_flow = safe_min(smoothing, respiration_mass_flow, (2.22E-03 * ustrip(u"kg", mass) * 15)u"g/s"; scale=1.0u"g/s")
 
     # get latent heat of vapourisation and compute heat exchange due to respiration
     latent_heat_vaporisation = enthalpy_of_vaporisation(lung_temperature)

--- a/src/smoothing.jl
+++ b/src/smoothing.jl
@@ -102,3 +102,21 @@ safe_min(s::SmoothBound, a, b; scale=oneunit(a-b)) = (a + b - safe_abs(s, a - b;
 """
 safe_clamp(s::SmoothingStrategy, x, lo, hi; scale=oneunit(x)) =
     safe_max(s, lo, safe_min(s, hi, x; scale); scale)
+
+"""
+    safe_gated_ratio(gate, num, den, fallback)
+
+`num / den` when `gate > 0`, else `fallback`. Keeps a `0/0` division out of the
+AD tape when both numerator and denominator vanish on the gate — Enzyme
+reverse-mode evaluates a discarded ratio's pullback under a ternary mask, so
+the kink at `gate = 0` poisons gradients of every input flowing into the
+operands. The `if/else` ensures the division never executes when the gate is
+closed. Both branches must return the same type for inference to stay Union-
+free; pass `fallback = zero(num/den)` (or any same-typed value) at the call
+site.
+
+Strategy-independent: this gate is always hard. Soft-blending the two arms
+would put the (NaN-producing) division back on the tape, defeating the point.
+"""
+@inline safe_gated_ratio(gate, num, den, fallback) =
+    gate > zero(gate) ? num / den : fallback

--- a/src/solve_metabolic_rate.jl
+++ b/src/solve_metabolic_rate.jl
@@ -57,14 +57,15 @@ NamedTuple with:
 - `energy_flows`: Heat flux components (solar, longwave, convection, etc.)
 - `mass_flows`: Water and gas exchange rates
 """
-function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_temperature)
+function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_temperature;
+                                smoothing::SmoothingStrategy=HardBound())
     environment_pars = stripparams(e.environment_pars)
     environment_vars = e.environment_vars
     opts = options(o)
     resp_pars = respiration_pars(o)
     metab_pars = metabolism_pars(o)
 
-    packed = _pack_sides(o, e, metab_pars.core_temperature, skin_temperature, insulation_temperature)
+    packed = _pack_sides(o, e, metab_pars.core_temperature, skin_temperature, insulation_temperature; smoothing)
     (; temps_out, side_bodies, sky_factor_ref, vegetation_factor_ref) = packed
 
     max_skin_temperature = max(temps_out[1].skin_temperature, temps_out[2].skin_temperature)
@@ -96,6 +97,7 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
             environment_vars.air_temperature;
             gas_fractions=environment_pars.gas_fractions,
             O2conversion=Kleiber1961(),
+            smoothing,
         ).balance)
 
         metabolic_heat_flow = zbrent(
@@ -114,6 +116,7 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
             environment_vars.air_temperature;
             gas_fractions=environment_pars.gas_fractions,
             O2conversion=Kleiber1961(),
+            smoothing,
         )
         metabolic_heat_flow = respiration_out.metabolic_heat_flow
     else
@@ -122,5 +125,5 @@ function solve_metabolic_rate(o::Organism, e, skin_temperature, insulation_tempe
     end
 
     resp_out_for_assembly = opts.respire ? respiration_out : nothing
-    return _assemble_multisided_output(o, e, metab_pars.core_temperature, metabolic_heat_flow, resp_out_for_assembly, packed)
+    return _assemble_multisided_output(o, e, metab_pars.core_temperature, metabolic_heat_flow, resp_out_for_assembly, packed; smoothing)
 end

--- a/src/solve_temperature.jl
+++ b/src/solve_temperature.jl
@@ -13,26 +13,29 @@ Find the steady-state temperature of an organism (animal or leaf) by root-findin
 
 Returns air temperature as the fallback `core_temperature` if root-finding fails.
 """
-function solve_temperature(organism, environment; temperature_bracket=(270.0u"K", 370.0u"K"))
-    solve_temperature(evaluation_strategy(organism), organism, environment; temperature_bracket)
+function solve_temperature(organism, environment; temperature_bracket=(270.0u"K", 370.0u"K"),
+                            smoothing::SmoothingStrategy=HardBound())
+    solve_temperature(evaluation_strategy(organism), organism, environment; temperature_bracket, smoothing)
 end
 
-function solve_temperature(::SingleBody, organism, environment; temperature_bracket=(270.0u"K", 370.0u"K"))
+function solve_temperature(::SingleBody, organism, environment; temperature_bracket=(270.0u"K", 370.0u"K"),
+                            smoothing::SmoothingStrategy=HardBound())
     lo = ustrip(u"K", temperature_bracket[1])
     hi = ustrip(u"K", temperature_bracket[2])
     fallback_temperature = environment.environment_vars.air_temperature
     try
         solved_temperature = zbrent(
-            T -> ustrip(u"W", heat_balance(T * u"K", organism, environment).heat_balance),
+            T -> ustrip(u"W", heat_balance(T * u"K", organism, environment; smoothing).heat_balance),
             lo, hi, 1e-3,
         )
-        heat_balance(solved_temperature * u"K", organism, environment)
+        heat_balance(solved_temperature * u"K", organism, environment; smoothing)
     catch
-        heat_balance(fallback_temperature, organism, environment)
+        heat_balance(fallback_temperature, organism, environment; smoothing)
     end
 end
 
-function solve_temperature(::MultiSided, organism, environment; temperature_bracket=(270.0u"K", 370.0u"K"))
+function solve_temperature(::MultiSided, organism, environment; temperature_bracket=(270.0u"K", 370.0u"K"),
+                            smoothing::SmoothingStrategy=HardBound())
     environment_pars = stripparams(environment.environment_pars)
     environment_vars = environment.environment_vars
     resp_pars  = respiration_pars(organism)
@@ -48,7 +51,7 @@ function solve_temperature(::MultiSided, organism, environment; temperature_brac
 
     function residual(temperature)
         core_temperature = temperature * u"K"
-        packed = _pack_sides(organism, environment, core_temperature, initial_skin_temperature, initial_insulation_temperature)
+        packed = _pack_sides(organism, environment, core_temperature, initial_skin_temperature, initial_insulation_temperature; smoothing)
         dmult = packed.sky_factor_ref + packed.vegetation_factor_ref
         vmult = 1 - dmult
         net_metabolic = packed.temps_out[1].flows.net_metabolic * dmult +
@@ -61,7 +64,7 @@ function solve_temperature(::MultiSided, organism, environment; temperature_brac
             MetabolicRates(; metabolic=metabolic_heat_flow, sum=metabolic_heat_flow, minimum=metabolic_heat_flow),
             resp_pars, resp_atmos, organism.body.shape.mass, lung_temperature,
             environment_vars.air_temperature;
-            gas_fractions=environment_pars.gas_fractions, O2conversion=Kleiber1961(),
+            gas_fractions=environment_pars.gas_fractions, O2conversion=Kleiber1961(), smoothing,
         ).respiration_heat_flow
         ustrip(u"W", metabolic_heat_flow - respiration_heat_flow - net_metabolic)
     end
@@ -73,7 +76,7 @@ function solve_temperature(::MultiSided, organism, environment; temperature_brac
     end
 
     # Re-run _pack_sides at converged temperature to assemble full output
-    packed = _pack_sides(organism, environment, equilibrium_temperature, initial_skin_temperature, initial_insulation_temperature)
+    packed = _pack_sides(organism, environment, equilibrium_temperature, initial_skin_temperature, initial_insulation_temperature; smoothing)
     dmult = packed.sky_factor_ref + packed.vegetation_factor_ref
     vmult = 1 - dmult
     skin_mean = packed.temps_out[1].skin_temperature * dmult + packed.temps_out[2].skin_temperature * vmult
@@ -84,9 +87,9 @@ function solve_temperature(::MultiSided, organism, environment; temperature_brac
         MetabolicRates(; metabolic=metabolic_heat_flow, sum=metabolic_heat_flow, minimum=metabolic_heat_flow),
         resp_pars, resp_atmos, organism.body.shape.mass, lung_temperature,
         environment_vars.air_temperature;
-        gas_fractions=environment_pars.gas_fractions, O2conversion=Kleiber1961(),
+        gas_fractions=environment_pars.gas_fractions, O2conversion=Kleiber1961(), smoothing,
     )
     metabolic_heat_flow = respiration_out.metabolic_heat_flow
 
-    _assemble_multisided_output(organism, environment, equilibrium_temperature, metabolic_heat_flow, respiration_out, packed)
+    _assemble_multisided_output(organism, environment, equilibrium_temperature, metabolic_heat_flow, respiration_out, packed; smoothing)
 end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -140,7 +140,7 @@ Morphological parameters relating to radiation exchange.
 - `conduction_area` — Area in contact with substrate (m²).
 
 """
-Base.@kwdef struct RadiationParameters{AD,AV,ED,EV,AS,AT,AC,FS,FG,FV,FB,VF} <:
+Base.@kwdef struct RadiationParameters{AD,AV,ED,EV,AS,AT,AC,FS,FG,FV,FB,VF,SO} <:
                    AbstractMorphologyParameters
     body_absorptivity_dorsal::AD = Param(0.85, bounds=(0.0, 1.0))
     body_absorptivity_ventral::AV = Param(0.85, bounds=(0.0, 1.0))
@@ -154,7 +154,7 @@ Base.@kwdef struct RadiationParameters{AD,AV,ED,EV,AS,AT,AC,FS,FG,FV,FB,VF} <:
     vegetation_view_factor::FV = Param(0.0, bounds=(0.0, 1.0))
     bush_view_factor::FB = Param(0.0, bounds=(0.0, 1.0))
     ventral_fraction::VF = Param(0.5, bounds=(0.0, 1.0))
-    solar_orientation = Intermediate()
+    solar_orientation::SO = Intermediate()
 end
 
 """

--- a/test/ectotherm.jl
+++ b/test/ectotherm.jl
@@ -154,7 +154,7 @@ atmospheric_pressure = (ecto_input.pres)u"Pa"
 relative_humidity = (ecto_input.RH/100)
 elevation = (ecto_input.elevation)u"m"
 wind_speed = (ecto_input.VEL)u"m/s"
-fluid = ecto_input.fluid
+fluid = ecto_input.fluid == 1 ? Water() : Air()
 zenith_angle = (ecto_input.Z)u"°"
 global_radiation = (ecto_input.QSOLR)u"W/m^2"
 ground_albedo = ecto_input.alpha_sub

--- a/test/endotherm.jl
+++ b/test/endotherm.jl
@@ -148,7 +148,7 @@ for shape_number in 1:4
             ground_emissivity=1.0,
             sky_emissivity=1.0,
             elevation=(endo_input.ELEV)u"m",
-            fluid=endo_input.FLTYPE,
+            fluid=endo_input.FLTYPE == 1 ? Water() : Air(),
             gas_fractions=GasFractions(
                 endo_input.O2GAS / 100.0,
                 endo_input.CO2GAS / 100.0,

--- a/test/environment.jl
+++ b/test/environment.jl
@@ -7,7 +7,7 @@ environment_pars = EnvironmentalPars(;
     ground_emissivity=1.0,
     sky_emissivity=1.0,
     elevation=0.0u"m",
-    fluid=0,
+    fluid=Air(),
     gas_fractions=GasFractions(0.2095, 0.0003, 0.79),
 )
 env_params = Model(environment_pars)

--- a/test/heat_balance.jl
+++ b/test/heat_balance.jl
@@ -62,7 +62,7 @@ environment_pars = EnvironmentalPars(;
     ground_emissivity    = 1.0,
     sky_emissivity       = 1.0,
     elevation            = 0.0u"m",
-    fluid                = 0,
+    fluid                = Air(),
     gas_fractions        = GasFractions(0.2095, 0.000412, 0.7902),
     convection_enhancement = 1.0,
 )
@@ -162,7 +162,7 @@ dorsal_insulation_temperature  = thermoreg.dorsal.insulation_temperature
 ins_d = insulation_properties(insulation_pars, dorsal_insulation_temperature * 0.7 + dorsal_skin_temperature * 0.3, pven)
 
 geometry_vars_d = GeometryVariables(;
-    side                    = :dorsal,
+    side                    = Dorsal(),
     conductance_coefficient = 0.0u"W/K",
     ventral_fraction        = pven,
     conduction_fraction     = external_conduction.conduction_fraction,

--- a/test/leaf.jl
+++ b/test/leaf.jl
@@ -23,7 +23,7 @@ environment_pars = EnvironmentalPars(;
     ground_emissivity=0.95,
     sky_emissivity=1.0,
     elevation=0.0u"m",
-    fluid=0,
+    fluid=Air(),
     gas_fractions,
 )
 


### PR DESCRIPTION
Type stability:
- Add SO type parameter to RadiationParameters for solar_orientation (was untyped, hence Any).
- Extract only used rad_pars fields (body_emissivity_*, solar_orientation) into nlp_pack output rather than storing the whole struct: stripparams on a RadiationParameters with unit-bearing Param fields infers as a UnionAll with free type variables and poisons the packed tuple.
- uconvert(u"W") both branches of the dorsal/ventral solar-flow if/else so mean_solar_flow infers concretely instead of Any.
- Anchor types from a single insulation_thermal_conductivity call in the bare-skin branch of insulation_properties instead of running four calls unconditionally; preserves the Union-free return without paying the wasted AD pullback cost.

AD safety:
- safe_gated_ratio helper for the conduction_fraction > 0 ? num/den : zero pattern that keeps 0/0 off the Enzyme tape; replaces three copies (each carrying ~25 lines of duplicated rationale) in radiant_temperature.

Smoothing coverage:
- Thread smoothing kwarg through solve_temperatures, solve_with/without_insulation!, _pack_sides, _assemble_multisided_output, solve_temperature, solve_metabolic_rate, heat_balance 3-arg, _radiative_convective_flows, and nlp_pack(MultiSidedNLP) so any function that accepts smoothing actually receives it.
- Make smoothing a kwarg (not positional) in the shape-dispatched net_metabolic_heat, mean_skin_temperature, radiant_temperature methods for a consistent calling convention.

Singletons:
- Replace Symbol body-side flags and integer fluid flags with BodySide (Dorsal/Ventral) and Fluid (Air/Water) singletons so dispatch erases the unused branch.
- nlp_pack now passes Dorsal() instead of the Symbol :dorsal (was a MethodError on GeometryVariables construction).

Drops budgerigar IPOPT warm-solve allocations from 25.3 to 12.0 KiB per solve.