### PR TITLE
Add arbitrary shape correlations for Nusselt number correlations in convection

### DIFF
--- a/src/HeatExchange.jl
+++ b/src/HeatExchange.jl
@@ -106,6 +106,7 @@ export ConductanceCoeffs,
     Water
 
 export CharacteristicDimFormula, VolumeCubeRoot, ScaledDimension, characteristic_dimension
+export ConvectionCorrelation, ShapeCorrelation, SimpleForcedCorrelation
 
 export MetabolicRateEquation, metabolic_rate, AndrewsPough2, Kleiber, McKechnieWolf, PlantDarkRespiration
 

--- a/src/biophysics.jl
+++ b/src/biophysics.jl
@@ -205,6 +205,7 @@ Calculate combined free and forced convective heat transfer for an organism.
 - `fluid::Fluid`: Fluid singleton (`Air()` or `Water()`)
 - `gas_fractions::GasFractions`: Gas fractions for air properties (default: `GasFractions()`)
 - `convection_enhancement`: Enhancement factor for forced convection (default: 1.0)
+- `correlation::ConvectionCorrelation`: Nusselt-number correlation to use (default: `ShapeCorrelation()`)
 
 # Returns
 NamedTuple with:
@@ -224,6 +225,7 @@ function convection(;
     convection_enhancement=1.0,
     characteristic_dimension_formula::CharacteristicDimFormula=VolumeCubeRoot(),
     smoothing::SmoothingStrategy=HardBound(),
+    correlation::ConvectionCorrelation=ShapeCorrelation(),
 )
     thermal_expansion_coefficient = 1 / air_temperature
     characteristic_dim = characteristic_dimension(characteristic_dimension_formula, body)
@@ -268,7 +270,7 @@ function convection(;
     temperature_difference = max(temperature_difference, 1.0e-6u"K")
     grashof_number = ((fluid_density^2) * thermal_expansion_coefficient * Unitful.gn * (characteristic_dim^3) * temperature_difference) / (dynamic_viscosity^2)
     reynolds_number = fluid_density * wind_speed * characteristic_dim /dynamic_viscosity
-    free_nusselt_number = nusselt_free(body.shape, grashof_number, prandtl_number)
+    free_nusselt_number = nusselt_free(correlation, body.shape, grashof_number, prandtl_number)
     free_heat_transfer_coefficient = (free_nusselt_number * fluid_conductivity) / characteristic_dim # heat transfer coefficient, free
     # calculating the Sherwood number from the Colburn analogy
     # Bird, Stewart & Lightfoot, 1960. Transport Phenomena. Wiley.
@@ -277,7 +279,7 @@ function convection(;
     free_mass_transfer_coefficient = free_sherwood_number * vapour_diffusivity / characteristic_dim # mass transfer coefficient, free
     free_convection_flow = free_heat_transfer_coefficient * area * (surface_temperature - air_temperature) # free convective heat loss at surface
     # forced convection
-    forced_nusselt_number = nusselt_forced(body.shape, reynolds_number) * convection_enhancement
+    forced_nusselt_number = nusselt_forced(correlation, body.shape, reynolds_number) * convection_enhancement
     # forced convection for object
     forced_heat_transfer_coefficient = forced_nusselt_number * fluid_conductivity / characteristic_dim # heat transfer coefficient, forced
     forced_sherwood_number = forced_nusselt_number * (schmidt_number / prandtl_number)^(1 / 3) # Sherwood number, forced

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -73,6 +73,39 @@ characteristic_dimension(::VolumeCubeRoot, body) =
 characteristic_dimension(sd::ScaledDimension, body) =
     sd.factor * getproperty(body.geometry.length, sd.dimension)
 
+# Convection correlation
+
+"""
+    ConvectionCorrelation
+
+Abstract supertype selecting which Nusselt-number correlation `convection()`
+uses for `nusselt_free`/`nusselt_forced`.
+"""
+abstract type ConvectionCorrelation end
+
+"""
+    ShapeCorrelation <: ConvectionCorrelation
+
+Dispatch `nusselt_free`/`nusselt_forced` on `body.shape` (default).
+"""
+struct ShapeCorrelation <: ConvectionCorrelation end
+
+"""
+    SimpleForcedCorrelation <: ConvectionCorrelation
+
+Forced convection only: `Nu = 0.6·√Re`, Pr-independent, no free-convection
+term (`nusselt_free` returns zero), no shape dependence. Cheaper and less
+complete than `ShapeCorrelation`, not more accurate.
+"""
+struct SimpleForcedCorrelation <: ConvectionCorrelation end
+
+nusselt_free(::ShapeCorrelation, shape, grashof_number, prandtl_number) =
+    nusselt_free(shape, grashof_number, prandtl_number)
+nusselt_forced(::ShapeCorrelation, shape, reynolds_number) =
+    nusselt_forced(shape, reynolds_number)
+nusselt_free(::SimpleForcedCorrelation, shape, grashof_number, prandtl_number) = zero(grashof_number)
+nusselt_forced(::SimpleForcedCorrelation, shape, reynolds_number) = 0.6 * sqrt(reynolds_number)
+
 """
     ExternalConductionParameters <: AbstractMorphologyParameters
 

--- a/test/biophysics.jl
+++ b/test/biophysics.jl
@@ -1,4 +1,5 @@
 using HeatExchange
+using BiophysicalGeometry
 using Test
 using Unitful
 using UnitfulMoles
@@ -45,4 +46,30 @@ using UnitfulMoles
     out_dry = evaporation(leaf_pars, mass_windy, atmos, area, surface_temperature, air_temperature;
         water_potential = -1e6u"J/kg")
     @test out_dry.evaporation_heat_flow < out.evaporation_heat_flow
+end
+
+@testset "SimpleForcedCorrelation" begin
+    body = Body(Ellipsoid(0.2u"g" |> u"kg", 700.0u"kg/m^3", 1.0, 100.0), Naked())
+    common = (; body, area=0.01u"m^2", air_temperature=u"K"(25.0u"°C"),
+        surface_temperature=u"K"(30.0u"°C"), atmospheric_pressure=101325.0u"Pa", fluid=Air())
+
+    windy = convection(; common..., wind_speed=2.0u"m/s", correlation=SimpleForcedCorrelation())
+    @test isfinite(ustrip(u"W", windy.convection_flow))
+    @test windy.convection_flow > 0.0u"W"
+
+    # No free-convection term: zero wind gives zero convective flow.
+    calm = convection(; common..., wind_speed=0.0u"m/s", correlation=SimpleForcedCorrelation())
+    @test calm.convection_flow == 0.0u"W"
+
+    # Nusselt correlation, not shape, drives forced convection: same
+    # Reynolds number gives the same Nu regardless of shape argument.
+    @test nusselt_forced(SimpleForcedCorrelation(), Plate(1.0u"kg", 1.0u"kg/m^3", 1.0, 1.0), 500.0) ==
+        nusselt_forced(SimpleForcedCorrelation(), Ellipsoid(1.0u"kg", 1.0u"kg/m^3", 1.0, 1.0), 500.0)
+    @test nusselt_forced(SimpleForcedCorrelation(), Plate(1.0u"kg", 1.0u"kg/m^3", 1.0, 1.0), 500.0) ≈ 0.6 * sqrt(500.0)
+    @test nusselt_free(SimpleForcedCorrelation(), Plate(1.0u"kg", 1.0u"kg/m^3", 1.0, 1.0), 1.0e5, 0.71) == 0.0
+
+    # ShapeCorrelation (default) includes free convection -- differs from
+    # SimpleForcedCorrelation even at the same wind speed.
+    shaped = convection(; common..., wind_speed=2.0u"m/s")
+    @test shaped.convection_flow != windy.convection_flow
 end


### PR DESCRIPTION
The package currently has shape-dispatched methods for Nusselt number correlations (nusselt_free and nusselt_forced) but sometimes users will want their own empirical ones to override them. This PR adds correlation::ConvectionCorrelation as a keyword for convection() with ShapeCorrelation (default) as the existing shape-dispatched behavior. An example used in Microclimate.jl for leaf convection in the canopy, SimpleForcedCorrelation is Nu=0.6*sqrt(Re), as an example.